### PR TITLE
Syntax highlighting for Java, C# and Scala

### DIFF
--- a/app/assets/javascripts/cyber-dojo_codemirror.js
+++ b/app/assets/javascripts/cyber-dojo_codemirror.js
@@ -25,11 +25,19 @@ var cyberDojo = (function(cd, $) {
     }
 
     switch (fileExtension(filename)) {
-      case '.cpp':
-      case '.hpp':
       case '.c':
-      case '.h':
+        return 'text/x-csrc';
+      case '.cpp':
         return 'text/x-c++src';
+      case '.hpp':
+      case '.h':
+        return 'text/x-c++hdr';
+      case '.java':
+        return 'text/x-java';
+      case '.cs':
+        return 'text/x-csharp';
+      case '.scala':
+        return 'text/x-scala';
       case '.clj':
         return 'text/x-clojure';
       case '.coffee':


### PR DESCRIPTION
Added syntax highlighting file extension associations for Java, C# and Scala and changed .c files to be parsed a C instead of C++