### PR TITLE
Enable Kotlin syntax highlighting

### DIFF
--- a/app/assets/javascripts/cyber-dojo_codemirror.js
+++ b/app/assets/javascripts/cyber-dojo_codemirror.js
@@ -133,6 +133,7 @@ var cyberDojo = ((cd, $) => {
       case '.hs'     : return 'text/x-haskell';
       case '.java'   : return 'text/x-java';
       case '.js'     : return 'text/javascript';
+      case '.kt'     : return 'text/x-kotlin';
       case '.md'     : return 'text/x-markdown';
       case '.php'    : return 'text/x-php';
       case '.py'     : return 'text/x-python';


### PR DESCRIPTION
Our mob saw that Kotlin is already supported by currently used CodeMirror version.
This change will enable the syntax highlighting for the Kotlin language.

Co-developed by @koushik-ms @dpolivaev @jagandeep @haraldreingruber ;)