### PR TITLE
Fix Forbidden 403 on POST behind HTTPS-terminating nginx proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,12 @@ ENV SHA=${COMMIT_SHA}
 ARG APP_DIR=/web
 ENV APP_DIR=${APP_DIR}
 
-RUN apk add --upgrade openssl=3.5.6-r0  # https://security.snyk.io/vuln/SNYK-ALPINE322-OPENSSL-15993406
-RUN apk add --upgrade musl=1.2.5-r12    # https://security.snyk.io/vuln/SNYK-ALPINE322-MUSL-16008606
+# https://security.snyk.io/vuln/SNYK-ALPINE322-OPENSSL-15993406
+RUN apk add --upgrade openssl=3.5.6-r0
+
+# https://security.snyk.io/vuln/SNYK-ALPINE322-MUSL-16008606
+RUN apk add --upgrade musl=1.2.5-r12
+RUN apk add --upgrade musl=1.2.5-r12 musl-utils=1.2.5-r12
 
 WORKDIR ${APP_DIR}/source
 COPY source/ .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ARG APP_DIR=/web
 ENV APP_DIR=${APP_DIR}
 
 RUN apk add --upgrade openssl=3.5.6-r0  # https://security.snyk.io/vuln/SNYK-ALPINE322-OPENSSL-15993406
+RUN apk add --upgrade musl=1.2.5-r12    # https://security.snyk.io/vuln/SNYK-ALPINE322-MUSL-16008606
 
 WORKDIR ${APP_DIR}/source
 COPY source/ .

--- a/source/app/app.rb
+++ b/source/app/app.rb
@@ -11,6 +11,7 @@ class App < Sinatra::Base
   set :views, "#{__dir__}/views"
   set :public_folder, File.expand_path('../public', __dir__)
   set :host_authorization, {}
+  set :protection, except: :http_origin
   enable :static
 
   def initialize


### PR DESCRIPTION
Sinatra::Base enables Rack::Protection by default, which includes HttpOrigin checking. Behind nginx (HTTPS terminated externally, HTTP internally), the browser sends Origin: https://beta.cyber-dojo.org but Rack computes base_url as http://beta.cyber-dojo.org - the scheme mismatch causes every POST to be rejected with 403 Forbidden.

Disabling HttpOrigin is safe here because config.ru already uses Rack::Protection::AuthenticityToken, which validates the per-request CSRF token on every POST. HttpOrigin is belt-and-suspenders protection that is incompatible with HTTPS-terminated reverse proxies.