### PR TITLE
Each test explicitly carries its own full ID

### DIFF
--- a/source/test/app_controllers/assets_test.rb
+++ b/source/test/app_controllers/assets_test.rb
@@ -2,11 +2,7 @@ require_relative 'app_controller_test_base'
 
 class AssetsTest < AppControllerTestBase
 
-  def self.hex_prefix
-    'EB5'
-  end
-
-  test '001', %w(
+  test 'EB5001', %w(
   | /assets/app.css returns 200 with text/css content-type
   ) do
     get '/assets/app.css'
@@ -14,7 +10,7 @@ class AssetsTest < AppControllerTestBase
     assert_includes last_response.content_type, 'text/css'
   end
 
-  test '002', %w(
+  test 'EB5002', %w(
   | /assets/app.js returns 200 with application/javascript content-type
   ) do
     get '/assets/app.js'

--- a/source/test/app_controllers/checkout_test.rb
+++ b/source/test/app_controllers/checkout_test.rb
@@ -2,13 +2,9 @@ require_relative 'app_controller_test_base'
 
 class CheckoutTest  < AppControllerTestBase
 
-  def self.hex_prefix
-    '7de'
-  end
-
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '176', %w(
+  test '7de176', %w(
   | in individual kata, checkout your own previous traffic-light
   ) do
     filename = 'hiker.sh'
@@ -51,7 +47,7 @@ class CheckoutTest  < AppControllerTestBase
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '177', %w(
+  test '7de177', %w(
   | in group kata, checkout a different avatar's traffic-light
   ) do
     filename = 'hiker.sh'

--- a/source/test/app_controllers/file_create_test.rb
+++ b/source/test/app_controllers/file_create_test.rb
@@ -2,13 +2,9 @@ require_relative 'app_controller_test_base'
 
 class FileCreateTest  < AppControllerTestBase
 
-  def self.hex_prefix
-    '87C'
-  end
-
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '276', %w(
+  test '87C276', %w(
   | file_create() creates a file-create event in saver 
   ) do
     created_filename = 'newfile.txt'

--- a/source/test/app_controllers/file_delete_test.rb
+++ b/source/test/app_controllers/file_delete_test.rb
@@ -2,13 +2,9 @@ require_relative 'app_controller_test_base'
 
 class FileDeleteTest  < AppControllerTestBase
 
-  def self.hex_prefix
-    '87C'
-  end
-
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '145', %w(
+  test '87C145', %w(
   | file_delete() creates a file-delete event in saver 
   ) do
     deleted_filename = 'readme.txt'

--- a/source/test/app_controllers/file_edit_test.rb
+++ b/source/test/app_controllers/file_edit_test.rb
@@ -2,13 +2,9 @@ require_relative 'app_controller_test_base'
 
 class FileEditTest  < AppControllerTestBase
 
-  def self.hex_prefix
-    '87C'
-  end
-
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '1cc', %w(
+  test '87C1cc', %w(
   | file_edit() does NOT create a file-edit event in saver 
   | when no file has changed
   ) do
@@ -25,7 +21,7 @@ class FileEditTest  < AppControllerTestBase
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '1cd', %w(
+  test '87C1cd', %w(
   | file_edit() creates a file-edit event in saver 
   | when there a file has changed
   ) do

--- a/source/test/app_controllers/file_rename_test.rb
+++ b/source/test/app_controllers/file_rename_test.rb
@@ -2,13 +2,9 @@ require_relative 'app_controller_test_base'
 
 class FileRenameTest  < AppControllerTestBase
 
-  def self.hex_prefix
-    '87C'
-  end
-
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '3ed', %w(
+  test '87C3ed', %w(
   | file_rename() creates a file-rename event in saver 
   ) do
     old_filename = 'readme.txt'

--- a/source/test/app_controllers/kata_bad_id_500_test.rb
+++ b/source/test/app_controllers/kata_bad_id_500_test.rb
@@ -5,11 +5,7 @@ class KataControllerTest  < AppControllerTestBase
 
   include CaptureStdoutStderr
 
-  def self.hex_prefix
-    'BE8'
-  end
-
-  test '76E', %w(
+  test 'BE876E', %w(
   | run_tests with bad ID is a 200 because SaverExceptions are swallowed
   ) do
     in_kata do |kata|

--- a/source/test/app_controllers/kata_edit_200_test.rb
+++ b/source/test/app_controllers/kata_edit_200_test.rb
@@ -2,11 +2,7 @@ require_relative 'app_controller_test_base'
 
 class KataEdit200Test  < AppControllerTestBase
 
-  def self.hex_prefix
-    'BE7'
-  end
-
-  test '9B9', %w(
+  test 'BE79B9', %w(
   | edit landing page smoke test
   ) do
     in_kata do |kata|
@@ -15,7 +11,7 @@ class KataEdit200Test  < AppControllerTestBase
     end
   end
 
-  test '9BA', %w(
+  test 'BE79BA', %w(
   | j() escapes special characters for safe embedding in JavaScript string literals
   ) do
     in_kata do |kata|

--- a/source/test/app_controllers/kata_error_pages_test.rb
+++ b/source/test/app_controllers/kata_error_pages_test.rb
@@ -5,11 +5,7 @@ class KataErrorPagesTest < AppControllerTestBase
 
   include CaptureStdoutStderr
 
-  def self.hex_prefix
-    'EB6'
-  end
-
-  test '001', %w(
+  test 'EB6001', %w(
   | GET /kata/edit2 (unknown route) returns 404
   ) do
     get '/kata/edit2'
@@ -17,7 +13,7 @@ class KataErrorPagesTest < AppControllerTestBase
     assert_includes last_response.body, '404'
   end
 
-  test '002', %w(
+  test 'EB6002', %w(
   | GET /kata/edit/:id with a bad id returns 500
   ) do
     App.set :raise_errors, false

--- a/source/test/app_controllers/mobbing_out_of_sync_test.rb
+++ b/source/test/app_controllers/mobbing_out_of_sync_test.rb
@@ -5,11 +5,7 @@ class MobbingOutOfSyncTest  < AppControllerTestBase
 
   include CaptureStdoutStderr
 
-  def self.hex_prefix
-    'zW7'
-  end
-
-  test 'B30', %w(
+  test 'zW7B30', %w(
   | given two (or more) laptops as the same avatar
   | and one has not synced (by hitting refresh in their browser)
   | and so their current traffic-light-index lags behind

--- a/source/test/app_controllers/predicted_test.rb
+++ b/source/test/app_controllers/predicted_test.rb
@@ -2,11 +2,7 @@ require_relative 'app_controller_test_base'
 
 class PredictedTest  < AppControllerTestBase
 
-  def self.hex_prefix
-    '1D3'
-  end
-
-  test '5b7', %w( 
+  test '1D35b7', %w(
   | predicted right, no auto-revert when wrong 
   ) do
     in_kata do |kata|
@@ -20,7 +16,7 @@ class PredictedTest  < AppControllerTestBase
 
   # - - - - - - - - - - - - - - - - - - - -
 
-  test '5b8', %w( 
+  test '1D35b8', %w(
   | predicted wrong, no auto-revert when wrong 
   ) do
     in_kata do |kata|

--- a/source/test/app_controllers/probe_test.rb
+++ b/source/test/app_controllers/probe_test.rb
@@ -2,11 +2,7 @@ require_relative 'app_controller_test_base'
 
 class ProbeTest < AppControllerTestBase
 
-  def self.hex_prefix
-    'EB4'
-  end
-
-  test '001', %w(
+  test 'EB4001', %w(
   | /alive returns 200 with alive?:true
   ) do
     get '/alive'
@@ -14,7 +10,7 @@ class ProbeTest < AppControllerTestBase
     assert_equal({ 'alive?' => true }, JSON.parse(last_response.body))
   end
 
-  test '002', %w(
+  test 'EB4002', %w(
   | /ready returns 200 with ready?:true
   ) do
     get '/ready'
@@ -22,7 +18,7 @@ class ProbeTest < AppControllerTestBase
     assert_equal({ 'ready?' => true }, JSON.parse(last_response.body))
   end
 
-  test '003', %w(
+  test 'EB4003', %w(
   | /web/sha returns 200 with sha key
   ) do
     get '/web/sha'

--- a/source/test/app_controllers/red_amber_green_test.rb
+++ b/source/test/app_controllers/red_amber_green_test.rb
@@ -2,11 +2,7 @@ require_relative 'app_controller_test_base'
 
 class RedAmberGreenTest  < AppControllerTestBase
 
-  def self.hex_prefix
-    'gh6'
-  end
-
-  test '223', %w( 
+  test 'gh6223', %w(
   | red-green-amber 
   ) do
     in_kata do |kata|
@@ -26,7 +22,7 @@ class RedAmberGreenTest  < AppControllerTestBase
 
   # - - - - - - - - - - - - - - - - - - - -
 
-  test '224', %w(
+  test 'gh6224', %w(
   | when run_tests() is 'red' and creates a file called outcome.special
   | then the colour becomes 'red_special
   | and the outcome.special file is not saved

--- a/source/test/app_controllers/revert_test.rb
+++ b/source/test/app_controllers/revert_test.rb
@@ -2,13 +2,9 @@ require_relative 'app_controller_test_base'
 
 class RevertTest  < AppControllerTestBase
 
-  def self.hex_prefix
-    '81F'
-  end
-
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '274', %w(
+  test '81F274', %w(
   | in individual kata, revert back to index=0 (created)
   | when there are *NO* file-events since creation
   ) do
@@ -33,7 +29,7 @@ class RevertTest  < AppControllerTestBase
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '275', %w(
+  test '81F275', %w(
   | in individual kata, revert back to our own previous traffic-light
   | when there are *NO* file-events since the previous traffic-light 
   ) do
@@ -67,7 +63,7 @@ class RevertTest  < AppControllerTestBase
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '276', %w(
+  test '81F276', %w(
   | in individual kata, revert back to our own previous traffic-light
   | when there *ARE* file-events since the previous traffic-light
   ) do
@@ -101,7 +97,7 @@ class RevertTest  < AppControllerTestBase
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '277', %w(
+  test '81F277', %w(
   | in individual kata, revert back to our own previous traffic-light
   | when the previous traffic-light was a special
   ) do
@@ -140,7 +136,7 @@ class RevertTest  < AppControllerTestBase
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '278', %w(
+  test '81F278', %w(
   | in individual kata, revert back to our own previous traffic-light
   | when there are multiple file-events to skip over before you
   | get to the previous traffic-light

--- a/source/test/app_controllers/review_test.rb
+++ b/source/test/app_controllers/review_test.rb
@@ -2,13 +2,9 @@ require_relative 'app_controller_test_base'
 
 class ReviewTest < AppControllerTestBase
 
-  def self.hex_prefix
-    '1CB'
-  end
-
   #- - - - - - - - - - - - - - - -
 
-  test '440', %w(
+  test '1CB440', %w(
   | was_index != now_index
   ) do
     [2].each do |version|
@@ -21,7 +17,7 @@ class ReviewTest < AppControllerTestBase
 
   #- - - - - - - - - - - - - - - -
 
-  test '441', %w(
+  test '1CB441', %w(
   | (was_index,now_index) == (-1,-1)
   ) do
     [2].each do |version|
@@ -34,13 +30,13 @@ class ReviewTest < AppControllerTestBase
 
   #- - - - - - - - - - - - - - - -
 
-  test '442', %w(
+  test '1CB442', %w(
   | was_index != now_index, review existing version=0 kata
   ) do
     assert_review_show('5rTJv5', 1, 2)
   end
 
-  test '443', %w(
+  test '1CB443', %w(
   | (was_index,now_index) == (-1,-1) review existing version=0 kata 
   ) do
     assert_review_show('5rTJv5', -1, -1)
@@ -48,7 +44,7 @@ class ReviewTest < AppControllerTestBase
 
   #- - - - - - - - - - - - - - - -
 
-  test '444', %w( 
+  test '1CB444', %w(
   | was_index != now_index, review new version=1 kata
   ) do
     in_kata { |kata|
@@ -57,7 +53,7 @@ class ReviewTest < AppControllerTestBase
     }
   end
 
-  test '445', %w(
+  test '1CB445', %w(
   | (was_index,now_index) == (-1,-1), review new version=1 kata
   ) do
     in_kata { |kata|

--- a/source/test/app_controllers/text_file_changes_test.rb
+++ b/source/test/app_controllers/text_file_changes_test.rb
@@ -2,13 +2,9 @@ require_relative 'app_controller_test_base'
 
 class TextFileChangesTest  < AppControllerTestBase
 
-  def self.hex_prefix
-    '8q5'
-  end
-
   #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '9DC', %w(
+  test '8q59DC', %w(
   |when cyber-dojo.sh deletes an existing text file
   |then the saver does NOT record it
   |because the illusion is the [test] is running in the browser
@@ -27,7 +23,7 @@ class TextFileChangesTest  < AppControllerTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '9DD', %w(
+  test '8q59DD', %w(
   | given cyber-dojo.sh contains a command to create new text file
   | then the saver records the new file
   ) do
@@ -46,7 +42,7 @@ class TextFileChangesTest  < AppControllerTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '9DE', %w(
+  test '8q59DE', %w(
   | given cyber-dojo.sh contains a command to change an existing text file
   | then the saver records the changed file
   ) do
@@ -65,7 +61,7 @@ class TextFileChangesTest  < AppControllerTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '736', %w(
+  test '8q5736', %w(
   | given cyber-dojo.sh contains a command to create a new text file called stdout
   | then the saver records it
   | but does not confuse it with the standard stdout stream
@@ -89,7 +85,7 @@ class TextFileChangesTest  < AppControllerTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '737', %w(
+  test '8q5737', %w(
   | given cyber-dojo.sh contains a command to create new text file called 'stderr'
   | then the saver records it 
   | but does not confuse it with the standard stdout stream
@@ -113,7 +109,7 @@ class TextFileChangesTest  < AppControllerTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '738', %w(
+  test '8q5738', %w(
   | given cyber-dojo.sh contains a command to create a new text file called 'status'
   | then the saver does record it
   | but does not confuse it with the standard status

--- a/source/test/app_controllers/timed_out_test.rb
+++ b/source/test/app_controllers/timed_out_test.rb
@@ -2,11 +2,7 @@ require_relative 'app_controller_test_base'
 
 class TimedOutTest  < AppControllerTestBase
 
-  def self.hex_prefix
-    'jB4'
-  end
-
-  test '221', %w( 
+  test 'jB4221', %w(
   | timed_out 
   ) do
     in_kata do |kata|

--- a/source/test/app_models/externals_test.rb
+++ b/source/test/app_models/externals_test.rb
@@ -7,13 +7,9 @@ end
 
 class ExternalsTest < AppModelsTestBase
 
-  def self.hex_prefix
-    'A1k'
-  end
-
   #- - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '880', %w(
+  test 'A1k880', %w(
   | setting an external class to the name of an existing class succeeds
   )  do
     exists = 'ExternalDouble'
@@ -22,7 +18,7 @@ class ExternalsTest < AppModelsTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '881', %w(
+  test 'A1k881', %w(
   | setting an external class to the name of a non-existent class raises StandardError
   ) do
     error = StandardError

--- a/source/test/app_models/kata_test.rb
+++ b/source/test/app_models/kata_test.rb
@@ -2,13 +2,9 @@ require_relative 'app_models_test_base'
 
 class KataTest < AppModelsTestBase
 
-  def self.hex_prefix
-    'Fb9'
-  end
-
   #- - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '862', %w(
+  test 'Fb9862', %w(
   | an individual kata is created from a well-formed manifest,
   | and is not a member of a group
   ) do
@@ -20,7 +16,7 @@ class KataTest < AppModelsTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '864', %w(
+  test 'Fb9864', %w(
   | after run_tests()/ran_tests(),
   | there is a new traffic-light event,
   | which is now the most recent event
@@ -43,7 +39,7 @@ class KataTest < AppModelsTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '860', %w(
+  test 'Fb9860', %w(
   | after revert,
   | there is a new traffic-light event,
   | which is now the most recent event
@@ -84,7 +80,7 @@ class KataTest < AppModelsTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '866', %w(
+  test 'Fb9866', %w(
   | kata.event(-1) returns the most recent event
   ) do
     in_new_kata do |kata|
@@ -109,7 +105,7 @@ class KataTest < AppModelsTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - -
 
-  v_tests [0,1,2], '824', %w(
+  v_tests [0,1,2], 'Fb9824', %w(
   | given a saver outage during a session
   | when kata.event(-1) is called
   | then v0 raises
@@ -138,7 +134,7 @@ class KataTest < AppModelsTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - -
 
-  v_tests [0,1,2], '825', %w(
+  v_tests [0,1,2], 'Fb9825', %w(
   | given two laptops as the same avatar
   | when one is behind (has not synced by hitting refresh in their browser)
   | and they hit the [test] button

--- a/source/test/app_models/runner_test.rb
+++ b/source/test/app_models/runner_test.rb
@@ -2,13 +2,9 @@ require_relative 'app_models_test_base'
 
 class RunnerTest < AppModelsTestBase
 
-  def self.hex_prefix
-    'Nn2'
-  end
-
   #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '151',
+  test 'Nn2151',
   'green: expected=42, actual=6*7' do
     runner.stub_run(outcome:'green')
     in_new_kata do |kata|
@@ -19,7 +15,7 @@ class RunnerTest < AppModelsTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '152',
+  test 'Nn2152',
   'timed_out: infinite loop' do
     runner.stub_run(outcome:'timed_out')
     in_new_kata do |kata|

--- a/source/test/app_services/externals_test.rb
+++ b/source/test/app_services/externals_test.rb
@@ -2,13 +2,9 @@ require_relative 'app_services_test_base'
 
 class ExternalsTest < AppServicesTestBase
 
-  def self.hex_prefix
-    '2aP'
-  end
-
   #- - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '2sK',
+  test '2aP2sK',
   'default http-proxy adapter classes' do
     assert runner.is_a?(RunnerStub)
     assert saver.is_a?(SaverService)

--- a/source/test/app_services/http_json_test.rb
+++ b/source/test/app_services/http_json_test.rb
@@ -3,10 +3,6 @@ require 'ostruct'
 
 class HttpJsonTest < AppServicesTestBase
 
-  def self.hex_prefix
-    '12D'
-  end
-
   def hex_setup
     set_runner_class('RunnerService')
   end
@@ -21,7 +17,7 @@ class HttpJsonTest < AppServicesTestBase
     end
   end
 
-  test '2C7',
+  test '12D2C7',
   'response.body is not JSON Hash raises' do
     set_http(HttpJsonRequesterNotJsonHashStub)
     stdout,stderr = capture_stdout_stderr do
@@ -51,7 +47,7 @@ class HttpJsonTest < AppServicesTestBase
     end
   end
 
-  test '2C9',
+  test '12D2C9',
   'response.body has exception key raises' do
     set_http(HttpJsonRequesterExceptionKeyStub)
     stdout,stderr = capture_stdout_stderr do
@@ -81,7 +77,7 @@ class HttpJsonTest < AppServicesTestBase
     end
   end
 
-  test '2C8',
+  test '12D2C8',
   'JSON Hash with no key to match path raises' do
     set_http(HttpJsonRequesterNoPathKeyStub)
     stdout,stderr = capture_stdout_stderr do    
@@ -111,7 +107,7 @@ class HttpJsonTest < AppServicesTestBase
     end
   end
 
-  test '2CA',
+  test '12D2CA',
   'JSON Hash with key to match path returns the value for the key' do
     set_http(HttpJsonRequesterHasPathKeyStub)
     json = runner.ready?

--- a/source/test/app_services/runner_service_test.rb
+++ b/source/test/app_services/runner_service_test.rb
@@ -4,17 +4,13 @@ require 'json'
 
 class RunnerServiceTest < AppServicesTestBase
 
-  def self.hex_prefix
-    '2BD'
-  end
-
   def hex_setup
     set_runner_class('RunnerService')
   end
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '3A7',
+  test '2BD3A7',
   'response.body failure is mapped to exception' do
     set_http(HttpJsonRequesterNotJsonStub)
     _stdout, _stderr = capture_stdout_stderr do
@@ -25,14 +21,14 @@ class RunnerServiceTest < AppServicesTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '3A8',
+  test '2BD3A8',
   'ready? smoke test' do
     assert runner.ready?
   end
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '812',
+  test '2BD812',
   'run() tests expecting 42 actual 6*9' do
     in_new_kata { |kata|
       pull_image(kata)  # To prevent timeout response

--- a/source/test/app_services/runner_stub_test.rb
+++ b/source/test/app_services/runner_stub_test.rb
@@ -3,17 +3,13 @@ require_relative 'runner_stub'
 
 class RunnerStubTest < AppServicesTestBase
 
-  def self.hex_prefix
-    'AF7'
-  end
-
   def hex_setup
     set_runner_class('RunnerStub')
   end
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '2C0', %w(
+  test 'AF72C0', %w(
   stub_run can stub stdout and leave
   stderr defaulted to stub empty-string and,
   status defaulted to stub zero and,
@@ -30,7 +26,7 @@ class RunnerStubTest < AppServicesTestBase
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '09C',
+  test 'AF709C',
   'stdout,stderr,status,outcome can all be stubbed explicitly' do
     stub = {
       stdout: 'Assertion failed',
@@ -48,7 +44,7 @@ class RunnerStubTest < AppServicesTestBase
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '97A',
+  test 'AF797A',
   'run without preceeding stub returns so/se/0/false/red' do
     run = runner.run_cyber_dojo_sh(unused_args)
     assert_equal 'so', run['stdout']['content']
@@ -59,7 +55,7 @@ class RunnerStubTest < AppServicesTestBase
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test '902',
+  test 'AF7902',
   'stub set in one thread has to be visible in another thread',
   'because app_controller methods are routed into a new thread' do
     stdout = 'syntax error line 1'

--- a/source/test/app_services/saver_service_test.rb
+++ b/source/test/app_services/saver_service_test.rb
@@ -4,13 +4,9 @@ require 'json'
 
 class SaverServiceTest < AppServicesTestBase
 
-  def self.hex_prefix
-    'D1E'
-  end
-
   #- - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test 'eJX',
+  test 'D1EeJX',
   'response.body failure is mapped to exception' do
     set_http(HttpJsonRequesterNotJsonStub)
     _stdout, _stderr = capture_stdout_stderr do
@@ -21,14 +17,14 @@ class SaverServiceTest < AppServicesTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test 'eJ0',
+  test 'D1EeJ0',
   'ready?() smoke test' do
     assert saver.ready?
   end
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test 'eJ1',
+  test 'D1EeJ1',
   'group_create() smoke test' do
     manifest = starter_manifest
     gid = saver.group_create(manifest)
@@ -39,7 +35,7 @@ class SaverServiceTest < AppServicesTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test 'eJ2',
+  test 'D1EeJ2',
   'kata_create() smoke test' do
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
@@ -50,7 +46,7 @@ class SaverServiceTest < AppServicesTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test 'eJ3',
+  test 'D1EeJ3',
   'group_join() - group_joined() smoke test' do
     manifest = starter_manifest
     gid = saver.group_create(manifest)
@@ -67,7 +63,7 @@ class SaverServiceTest < AppServicesTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test 'QJ2',
+  test 'D1EQJ2',
   'kata_ran_tests() smoke test' do
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
@@ -75,7 +71,7 @@ class SaverServiceTest < AppServicesTestBase
     assert_equal 2, saver.kata_events(kid).size
   end
 
-  test 'QJ3',
+  test 'D1EQJ3',
   'kata_predicted_right() smoke test' do
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
@@ -87,7 +83,7 @@ class SaverServiceTest < AppServicesTestBase
     assert_equal 2, saver.kata_events(kid).size
   end
 
-  test 'QJ4',
+  test 'D1EQJ4',
   'kata_predicted_wrong() smoke test' do
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
@@ -101,7 +97,7 @@ class SaverServiceTest < AppServicesTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test 'QJ5',
+  test 'D1EQJ5',
   'kata_reverted() smoke test' do
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
@@ -120,7 +116,7 @@ class SaverServiceTest < AppServicesTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test 'QJ6',
+  test 'D1EQJ6',
   'kata_checked_out() smoke test' do
     manifest = starter_manifest
     gid = saver.group_create(manifest)
@@ -141,7 +137,7 @@ class SaverServiceTest < AppServicesTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test 'QJ7',
+  test 'D1EQJ7',
   'kata_file_edit() smoke test' do
     manifest = starter_manifest
     manifest['version'] = 2
@@ -152,7 +148,7 @@ class SaverServiceTest < AppServicesTestBase
     assert_equal 2, next_index
   end
 
-  test 'QJ8',
+  test 'D1EQJ8',
   'kata_file_create() smoke test' do
     manifest = starter_manifest
     manifest['version'] = 2
@@ -161,7 +157,7 @@ class SaverServiceTest < AppServicesTestBase
     assert_equal 2, next_index
   end
 
-  test 'QJ9',
+  test 'D1EQJ9',
   'kata_file_delete() smoke test' do
     manifest = starter_manifest
     manifest['version'] = 2
@@ -171,7 +167,7 @@ class SaverServiceTest < AppServicesTestBase
     assert_equal 2, next_index
   end
 
-  test 'QJA',
+  test 'D1EQJA',
   'kata_file_rename() smoke test' do
     manifest = starter_manifest
     manifest['version'] = 2
@@ -183,7 +179,7 @@ class SaverServiceTest < AppServicesTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test 'eJ5',
+  test 'D1EeJ5',
   'kata_event() smoke test' do
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
@@ -193,7 +189,7 @@ class SaverServiceTest < AppServicesTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  test 'eJ6',
+  test 'D1EeJ6',
   'kata_events() smoke test' do
     manifest = starter_manifest
     kid = saver.kata_create(manifest)

--- a/source/test/lib/cleaner_test.rb
+++ b/source/test/lib/cleaner_test.rb
@@ -3,15 +3,11 @@ require_relative '../../lib/cleaner'
 
 class CleanerTest < LibTestBase
 
-  def self.hex_prefix
-    '3d9'
-  end
-
   include Cleaner
 
   # - - - - - - - - - - - - - - - - - - -
 
-  test '982',
+  test '3d9982',
   'cleaned_string cleans away invalid-encodings' do
     refute dirty.valid_encoding?
     clean = cleaned_string(dirty)
@@ -21,7 +17,7 @@ class CleanerTest < LibTestBase
 
   # - - - - - - - - - - - - - - - - - - -
 
-  test '983',
+  test '3d9983',
   'cleaned_string leaves valid strings untouched' do
     before = 'once upon a time'
     assert before.valid_encoding?
@@ -32,7 +28,7 @@ class CleanerTest < LibTestBase
 
   # - - - - - - - - - - - - - - - - - - -
 
-  test '984',
+  test '3d9984',
   'cleaned_files cleans away invalid-encodings' do
     files = {
       '/sandbox/dirty.txt' => dirty,
@@ -48,7 +44,7 @@ class CleanerTest < LibTestBase
 
   # - - - - - - - - - - - - - - - - - - -
 
-  test '985', %w(
+  test '3d9985', %w(
   cleaned_files() cleans away invalid-encodings
   and then converts Windows line-endings
   ) do
@@ -69,7 +65,7 @@ class CleanerTest < LibTestBase
 
   # - - - - - - - - - - - - - - - - - - -
 
-  test '986',
+  test '3d9986',
   'cleaned_files converts Windows line-endings to Unix line-endings' do
     plain = [
       'the boy stood on',
@@ -86,7 +82,7 @@ class CleanerTest < LibTestBase
 
   # - - - - - - - - - - - - - - - - - - -
 
-  test '987',
+  test '3d9987',
   'cleaned_files leaves Unix line-endings untouched' do
     plain = [
       'the boy stood on',

--- a/source/test/lib/files_from_test.rb
+++ b/source/test/lib/files_from_test.rb
@@ -3,15 +3,11 @@ require_relative '../../lib/files_from'
 
 class FilesFromTest < LibTestBase
 
-  def self.hex_prefix
-    '640'
-  end
-
   include FilesFrom
 
   # - - - - - - - - - - - - - - - - -
 
-  test 'DD8', %w(
+  test '640DD8', %w(
   files_from removes output
   ) do
     file_content = {
@@ -25,7 +21,7 @@ class FilesFromTest < LibTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  test 'DD9', %w(
+  test '640DD9', %w(
   files_from truncates to 50K content
   ) do
     biggest = "X" * (50 * 1024)

--- a/source/test/lib/sha_test.rb
+++ b/source/test/lib/sha_test.rb
@@ -2,13 +2,9 @@ require_relative 'lib_test_base'
 
 class ShaTest < LibTestBase
 
-  def self.hex_prefix
-    'Fv3'
-  end
-
   # - - - - - - - - - - - - - - - - -
 
-  test '191', %w(
+  test 'Fv3191', %w(
   sha of git commit for image is set as env-var
   ) do
     sha = ENV['SHA']

--- a/source/test/lib/time_adapter_test.rb
+++ b/source/test/lib/time_adapter_test.rb
@@ -3,13 +3,9 @@ require_relative '../../lib/time_adapter'
 
 class TimeAdapterTest < LibTestBase
 
-  def self.hex_prefix
-    'x81'
-  end
-
   # - - - - - - - - - - - - - -
 
-  test '9F0',
+  test 'x819F0',
   'now returns 7 integers to make a Time from' do
     time = TimeAdapter.new
     now1 = time.now

--- a/source/test/test_base.rb
+++ b/source/test/test_base.rb
@@ -5,10 +5,10 @@ require 'minitest/autorun'
 
 class TestBase < Minitest::Test
 
-  def self.v_tests(versions, hex_prefix, *lines, &block)
+  def self.v_tests(versions, id_stem, *lines, &block)
     versions.each do |version|
       v_lines = ["<version=#{version}>"] + lines
-      test(hex_prefix + version.to_s, *v_lines, &block)
+      test(id_stem + version.to_s, *v_lines, &block)
     end
   end
 

--- a/source/test/test_hex_id_helpers.rb
+++ b/source/test/test_hex_id_helpers.rb
@@ -31,7 +31,6 @@ module TestHexIdHelpers # mix-in
       src = block.source_location
       src_file = File.basename(src[0])
       src_line = src[1].to_s
-      id = hex_prefix + id
       name = words.join(' ')
       # check test-id is well-formed
       diagnostic = "'#{id}',#{name}"


### PR DESCRIPTION
Remove the hex_prefix class method from every test file and the hex_prefix + id concatenation from TestHexIdHelpers#test, so each test call states its complete ID directly. Matches the convention already used in the saver repo. Also rename the v_tests parameter from hex_prefix to id_stem to reflect its new role.