### PR TITLE
Add missing test coverage for hashed asset routes and Responder#post …

### DIFF
--- a/source/test/app_controllers/assets_test.rb
+++ b/source/test/app_controllers/assets_test.rb
@@ -3,19 +3,38 @@ require_relative 'app_controller_test_base'
 class AssetsTest < AppControllerTestBase
 
   test 'EB5001', %w(
-  | /assets/app.css returns 200 with text/css content-type
+  | hashed CSS path returns 200 with text/css and one-year cache-control
   ) do
-    get '/assets/app.css'
-    assert last_response.ok?
+    get App::CSS_PATH
+    assert_equal 200, last_response.status
     assert_includes last_response.content_type, 'text/css'
+    assert_includes last_response.headers['Cache-Control'], 'max-age=31536000'
   end
 
   test 'EB5002', %w(
-  | /assets/app.js returns 200 with application/javascript content-type
+  | hashed JS path returns 200 with text/javascript and one-year cache-control
+  ) do
+    get App::JS_PATH
+    assert_equal 200, last_response.status
+    assert_includes last_response.content_type, 'text/javascript'
+    assert_includes last_response.headers['Cache-Control'], 'max-age=31536000'
+  end
+
+  # These two tests cover the old bare paths that are still served via Sinatra's
+  # static middleware. They are due to be retired once the bare paths are removed.
+
+  test 'EB5003', %w(
+  | /assets/app.css (unhashed) still returns 200
+  ) do
+    get '/assets/app.css'
+    assert_equal 200, last_response.status
+  end
+
+  test 'EB5004', %w(
+  | /assets/app.js (unhashed) still returns 200
   ) do
     get '/assets/app.js'
-    assert last_response.ok?
-    assert_includes last_response.content_type, 'text/javascript'
+    assert_equal 200, last_response.status
   end
 
 end

--- a/source/test/app_services/saver_service_test.rb
+++ b/source/test/app_services/saver_service_test.rb
@@ -17,6 +17,17 @@ class SaverServiceTest < AppServicesTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - - -
 
+  test 'D1EeJY',
+  'response.body failure on a post call is mapped to exception' do
+    set_http(HttpJsonRequesterNotJsonStub)
+    _stdout, _stderr = capture_stdout_stderr do
+      error = assert_raises(SaverService::Error) { saver.group_join('some_id') }
+      assert_equal 'body is not JSON', error.message, :error_message
+    end
+  end
+
+  #- - - - - - - - - - - - - - - - - - - - - - - - - -
+
   test 'D1EeJ0',
   'ready?() smoke test' do
     assert saver.ready?


### PR DESCRIPTION
…rescue

assets_test.rb: drive App::CSS_PATH and App::JS_PATH directly and assert the one-year Cache-Control header set by app.rb lines 74-84.

saver_service_test.rb: cover the post rescue (responder.rb line 27) via group_join, which avoids any prior get call that would have raised first.