### PR TITLE
Remove explicit aws_rolename; now defaults to gh_actions_services

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,6 @@ jobs:
     needs: [build-image]
     uses: cyber-dojo/snyk-scanning/.github/workflows/artifact_snyk_test.yml@main
     with:
-      aws_rolename: gh_actions_services
       artifact_name: ${{ needs.build-image.outputs.tagged_image_name }}
       kosli_flow: ${{vars.KOSLI_FLOW}}
       kosli_trail: ${{github.sha}}


### PR DESCRIPTION
The upstream reusable workflow now defaults aws_rolename to gh_actions_services, so passing it explicitly is redundant.