### PR TITLE
Enable CSRF token enforcement on POST requests (Phase 2)

### DIFF
--- a/source/app/app.rb
+++ b/source/app/app.rb
@@ -26,10 +26,9 @@ class App < Sinatra::Base
       @csrf_token = SecureRandom.hex(32)
       response.set_cookie('csrf_token', value: @csrf_token, path: '/')
     end
-    # Phase 2: uncomment once all users have reloaded and have the csrf_token cookie
-    # unless %w[GET HEAD OPTIONS TRACE].include?(request.request_method)
-    #   halt 403, 'Forbidden' unless params['authenticity_token'] == @csrf_token
-    # end
+    unless %w[GET HEAD OPTIONS TRACE].include?(request.request_method)
+      halt 403, 'Forbidden' unless params['authenticity_token'] == @csrf_token
+    end
   end
 
   PUBLIC_DIR = File.expand_path('../public', __dir__)

--- a/source/app/assets/javascripts/cyber-dojo_csrf.js
+++ b/source/app/assets/javascripts/cyber-dojo_csrf.js
@@ -1,0 +1,11 @@
+/*global jQuery*/
+'use strict';
+(($) => {
+  $(document).ajaxSend((event, xhr, settings) => {
+    if (settings.type !== 'GET') {
+      const token = $('meta[name="csrf-token"]').attr('content');
+      settings.data = (settings.data ? settings.data + '&' : '') +
+        'authenticity_token=' + encodeURIComponent(token);
+    }
+  });
+})(jQuery);

--- a/source/test/app_controllers/app_controller_test_base.rb
+++ b/source/test/app_controllers/app_controller_test_base.rb
@@ -38,6 +38,13 @@ class AppControllerTestBase < TestBase
     Kata.new(self, @id)
   end
 
+  def post(path, params = {}, env = {})
+    unless rack_mock_session.cookie_jar['csrf_token']
+      get '/alive'
+    end
+    super(path, params.merge(authenticity_token: rack_mock_session.cookie_jar['csrf_token']), env)
+  end
+
   def post_json(path, params)
     if params.key?(:data)
       params[:data] = Rack::Utils.build_nested_query(params[:data])


### PR DESCRIPTION
Phase 1 (deployed April 14) set the csrf_token cookie on all responses. Phase 2 enables the enforcement check that was left commented out pending all users reloading. Adds a global jQuery ajaxSend hook so all POST requests automatically include the token, and updates the controller test base to seed the cookie and merge the token into POST params.

Users with a kata page open before this deploy will get one 403 on their next test run; reloading the page picks up the new JS and self-heals.