### PR TITLE
Simplify fork dialog from 3 options to 2 (#262)

### DIFF
--- a/source/app/assets/stylesheets/fork-dialog.scss
+++ b/source/app/assets/stylesheets/fork-dialog.scss
@@ -5,13 +5,36 @@
   button.kata, button.group
   {
     display: block;
-    margin-top: 6px;
+    margin-top: 10px;
     margin-left: auto;
     margin-right: auto;
-    padding: 8px;
-    font-size: 25px;
+    padding: 10px 12px;
     @include non-code-font();
-    width: 230px;
+    width: 288px;
     text-align: left;
+
+    .fork-option-name
+    {
+      display: block;
+      font-size: 28px;
+      letter-spacing: 0.02em;
+      margin-bottom: 4px;
+    }
+
+    ul
+    {
+      margin: 0;
+      padding-left: 1.2em;
+      font-size: 13px;
+      list-style: disc;
+    }
+
+    .fork-option-note
+    {
+      display: block;
+      margin-top: 4px;
+      font-size: 12px;
+      color: #666;
+    }
   }
 }

--- a/source/app/views/review/_fork_button.erb
+++ b/source/app/views/review/_fork_button.erb
@@ -1,6 +1,6 @@
 <button id="fork-button" type="button">fork</button>
 
-<dialog id="fork-dialog" style="width:270px">
+<dialog id="fork-dialog" style="width:320px">
   <header>
     <span class="dialog-title">fork</span>
     <button type="button" class="dialog-close">close</button>
@@ -9,9 +9,23 @@
     create a new practice<br/>
     from this traffic-light's files
   </div>
-  <button class="kata"  type="button">ensemble style</button>
-  <button class="group" type="button">classroom style</button>
-  <button class="kata"  type="button">solo style</button>
+  <button class="group" type="button">
+    <span class="fork-option-name">classroom</span>
+    <ul>
+      <li>multiple avatars (eg, lion, salmon, tuna)</li>
+      <li>dashboard showing all avatars</li>
+      <li>each avatar has own source files</li>
+    </ul>
+  </button>
+  <button class="kata" type="button">
+    <span class="fork-option-name">single</span>
+    <ul>
+      <li>no avatar</li>
+      <li>no dashboard</li>
+      <li>one set of source files</li>
+    </ul>
+    <span class="fork-option-note">(can take turns, ensemble-style)</span>
+  </button>
 </dialog>
 
 <script>


### PR DESCRIPTION
User feedback was that ensemble/classroom/solo was confusing. Collapse ensemble and solo (both /kata/fork) into a single "single" option with a brief description, and rename the group option to "classroom". Add bullet descriptions to both buttons to make the difference clear at a glance.