### PR TITLE
Remove saver interaction from info dialogs (donate/charity/sponsorship)

### DIFF
--- a/source/app/views/shared/_charity_button.erb
+++ b/source/app/views/shared/_charity_button.erb
@@ -42,13 +42,6 @@
   const button = dialog.previousElementSibling;
   $(dialog).on('close', () => { if (cd.kata && cd.kata.editor) cd.kata.editor.refocus(); });
   $('.dialog-close', dialog).click(() => dialog.close());
-  $(button).click(() => {
-    // saveAnyFileChangesITE is only defined on the kata edit page, not the standalone review page
-    if (cd.saveAnyFileChangesITE) {
-      cd.saveAnyFileChangesITE(() => dialog.showModal());
-    } else {
-      dialog.showModal();
-    }
-  });
+  $(button).click(() => dialog.showModal());
 })();
 </script>

--- a/source/app/views/shared/_donate_button.erb
+++ b/source/app/views/shared/_donate_button.erb
@@ -30,13 +30,6 @@
   const button = dialog.previousElementSibling;
   $(dialog).on('close', () => { if (cd.kata && cd.kata.editor) cd.kata.editor.refocus(); });
   $('.dialog-close', dialog).click(() => dialog.close());
-  $(button).click(() => {
-    // saveAnyFileChangesITE is only defined on the kata edit page, not the standalone review page
-    if (cd.saveAnyFileChangesITE) {
-      cd.saveAnyFileChangesITE(() => dialog.showModal());
-    } else {
-      dialog.showModal();
-    }
-  });
+  $(button).click(() => dialog.showModal());
 })();
 </script>

--- a/source/app/views/shared/_sponsorship_button.erb
+++ b/source/app/views/shared/_sponsorship_button.erb
@@ -28,13 +28,6 @@
   const button = dialog.previousElementSibling;
   $(dialog).on('close', () => { if (cd.kata && cd.kata.editor) cd.kata.editor.refocus(); });
   $('.dialog-close', dialog).click(() => dialog.close());
-  $(button).click(() => {
-    // saveAnyFileChangesITE is only defined on the kata edit page, not the standalone review page
-    if (cd.saveAnyFileChangesITE) {
-      cd.saveAnyFileChangesITE(() => dialog.showModal());
-    } else {
-      dialog.showModal();
-    }
-  });
+  $(button).click(() => dialog.showModal());
 })();
 </script>


### PR DESCRIPTION
Opening these dialogs does not need to persist file edits to the saver service. Only structural file events (create, delete, rename, switch) warrant an inter-test event save.