### PR TITLE
Remove /web/sha probe and tests

### DIFF
--- a/bin/probe_demo.sh
+++ b/bin/probe_demo.sh
@@ -14,7 +14,6 @@ main()
   echo 'API: probing'
   curl_200 GET /alive?
   curl_200 GET /ready?
-  curl_200 GET /web/sha
   echo
 }
 

--- a/source/test/app_controllers/probe_test.rb
+++ b/source/test/app_controllers/probe_test.rb
@@ -18,14 +18,6 @@ class ProbeTest < AppControllerTestBase
     assert_equal({ 'ready?' => true }, JSON.parse(last_response.body))
   end
 
-  test 'EB4003', %w(
-  | /web/sha returns 200 with sha key
-  ) do
-    get '/web/sha'
-    assert last_response.ok?
-    assert JSON.parse(last_response.body).key?('sha')
-  end
-
   test 'EB4004', %w(
   | /alive/ (trailing slash) returns 200 with alive?:true
   ) do
@@ -40,14 +32,6 @@ class ProbeTest < AppControllerTestBase
     get '/ready/'
     assert last_response.ok?
     assert_equal({ 'ready?' => true }, JSON.parse(last_response.body))
-  end
-
-  test 'EB4006', %w(
-  | /web/sha/ (trailing slash) returns 200 with sha key
-  ) do
-    get '/web/sha/'
-    assert last_response.ok?
-    assert JSON.parse(last_response.body).key?('sha')
   end
 
 end


### PR DESCRIPTION
The route is being deleted; nothing should still be calling or verifying it.