### PR TITLE
Fix 403 on checkout and revert by migrating to fetch()

### DIFF
--- a/source/app/views/kata/run_tests.js.erb
+++ b/source/app/views/kata/run_tests.js.erb
@@ -142,7 +142,17 @@
       id: cd.kata.id,      // eg 'Xd4f2P'
       index: cd.kata.index // eg 18 (reverting to, eg 16)
     };
-    $.post('/kata/revert', args, (data) => {
+    fetch('/kata/revert', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+        'X-Requested-With': 'XMLHttpRequest'
+      },
+      body: new URLSearchParams(args)
+    })
+    .then(r => r.json())
+    .then(data => {
       cd.kata.incrementIndex();
       cd.kata.editor.deleteFiles();
       for (const filename in data.files) {
@@ -153,7 +163,7 @@
       cd.kata.editor.output(data.stdout.content, data.stderr.content, data.status);
       cd.kata.tabs.output().click();
       cd.kata.appendTrafficLight(data.light, {scrollIntoView:true});
-    }, 'json');
+    });
   };
 
   //- - - - - - - - - - - - - - - - - - - - - - - - -

--- a/source/app/views/review/_checkout_button.erb
+++ b/source/app/views/review/_checkout_button.erb
@@ -52,7 +52,17 @@ $(() => {
       src_avatar_index: review.avatarIndex
     };
     cd.settings.showButton();
-    $.post('/kata/checkout', args, (data) => {
+    fetch('/kata/checkout', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+        'X-Requested-With': 'XMLHttpRequest'
+      },
+      body: new URLSearchParams(args)
+    })
+    .then(r => r.json())
+    .then(data => {
       kata.incrementIndex();
       kata.editor.deleteFiles();
       for (const filename in data.files) {
@@ -61,9 +71,9 @@ $(() => {
       }
       kata.editor.output(data.stdout.content, data.stderr.content, data.status);
       kata.tabs.output().click();
-      kata.filenames.refresh();      
+      kata.filenames.refresh();
       kata.appendTrafficLight(data.light, {scrollIntoView: true});
-    }, 'json');
+    });
   };
 
 });

--- a/source/app/views/review/_fork_button.erb
+++ b/source/app/views/review/_fork_button.erb
@@ -24,7 +24,7 @@
       <li>no dashboard</li>
       <li>one set of source files</li>
     </ul>
-    <span class="fork-option-note">If you want an ensemble/mob style practice, use this style and simply take turns.</span>
+    <span class="fork-option-note">If you want an ensemble/mob style practice, choose this and take turns.</span>
   </button>
 </dialog>
 


### PR DESCRIPTION
The commit that deleted cyber-dojo_csrf.js (the global jQuery ajaxSend CSRF hook) missed two $.post() calls: /kata/checkout in _checkout_button.erb and /kata/revert in run_tests.js.erb. Without the hook, those requests reach Sinatra without a CSRF token and are rejected with 403. Migrate both to fetch() with explicit X-CSRF-Token and X-Requested-With headers, matching the pattern used elsewhere.