### PR TITLE
Make email addresses in feedback and sponsorship dialogs clickable

### DIFF
--- a/source/app/views/shared/_feedback.erb
+++ b/source/app/views/shared/_feedback.erb
@@ -6,7 +6,7 @@
     <button type="button" class="dialog-close">close</button>
   </header>
   <div class="info">
-    Please email us at <em>feedback@cyber-dojo.org</em>
+    Please email us at <a href="mailto:feedback@cyber-dojo.org">feedback@cyber-dojo.org</a>
     <ul>
       <li>make a suggestion?</li>
       <li>report an error?</li>

--- a/source/app/views/shared/_sponsorship_button.erb
+++ b/source/app/views/shared/_sponsorship_button.erb
@@ -14,7 +14,7 @@
        target="_blank">cyber-dojo Foundation</a> charity.
     <br/><br/>
     If you are interested in being a sponsor
-    please email sponsor@cyber-dojo.org
+    please email <a href="mailto:sponsor@cyber-dojo.org">sponsor@cyber-dojo.org</a>
   </div>
 </dialog>
 


### PR DESCRIPTION
Convert plain-text email addresses to mailto: links so users can click to open their email client directly from the dialogs.