### PR TITLE
Remove micro-services button from app-bar

### DIFF
--- a/source/app/views/shared/_info.erb
+++ b/source/app/views/shared/_info.erb
@@ -4,7 +4,6 @@
 <%= partial('shared/feedback') %>
 <%= partial('shared/help') %>
 <%= partial('shared/hotkeys') %>
-<%= partial('shared/micro_services') %>
 <%= partial('shared/traffic_lights') %>
 
 <script>


### PR DESCRIPTION
The button opened a Kosli URL showing running cyber-dojo micro-services. It is no longer needed.