### PR TITLE
Remove defunct Google Analytics snippet

### DIFF
--- a/source/app/views/layouts/application.erb
+++ b/source/app/views/layouts/application.erb
@@ -131,15 +131,6 @@
             crossorigin="anonymous"></script>
     <script src="<%= JS_PATH %>"></script>
 
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-15608469-5', 'cyber-dojo.org');
-      ga('send', 'pageview');
-    </script>
-
   </head>
 
   <body>

--- a/source/app/views/layouts/error.erb
+++ b/source/app/views/layouts/error.erb
@@ -12,15 +12,6 @@
     <link rel="stylesheet" href="/assets/app.css">
     <script src="/assets/app.js"></script>
 
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-15608469-5', 'cyber-dojo.org');
-      ga('send', 'pageview');
-    </script>
-
   </head>
 
   <body>


### PR DESCRIPTION
Universal Analytics was sunset by Google in July 2023. The requests were still firing on every page load but no data was being collected.