### PR TITLE
Make v0 and v1 katas read-only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,10 @@ test:
 	${PWD}/bin/run_tests.sh
 
 count ?= 1
+v ?= 2
 
 demo:
-	${PWD}/bin/demo.sh ${count}
+	${PWD}/bin/demo.sh ${count} ${v}
 
 probe_demo:
 	${PWD}/bin/probe_demo.sh

--- a/bin/demo.sh
+++ b/bin/demo.sh
@@ -46,7 +46,16 @@ docker ps -aq | xargs docker rm -f
 web_build
 up_nginx
 readonly COUNT="${1:-1}"
+readonly KATA_VERSION="${2:-2}"
 copy_in_saver_test_data # eg 5U2J18 (v1)  5rTJv5 (v0)
-id="$(create_v2_kata "${COUNT}")"
-echo "v2 Kata ID=${id}"
-open "http://localhost:80/kata/edit/${id}"
+if [ "${KATA_VERSION}" = "0" ]; then
+  echo "v0 Kata ID=5rTJv5"
+  open "http://localhost:80/kata/edit/5rTJv5"
+elif [ "${KATA_VERSION}" = "1" ]; then
+  echo "v1 Kata ID=RNCzUr"
+  open "http://localhost:80/kata/edit/RNCzUr"
+else
+  id="$(create_v2_kata "${COUNT}")"
+  echo "v2 Kata ID=${id}"
+  open "http://localhost:80/kata/edit/${id}"
+fi

--- a/source/app/assets/javascripts/cyber-dojo_codemirror.js
+++ b/source/app/assets/javascripts/cyber-dojo_codemirror.js
@@ -87,7 +87,7 @@ var cyberDojo = ((cd, $) => {
   const editorOptions = (filename) => {
     return {
           indentUnit: cd.kata.editor.tabSize(),
-            readOnly: cd.kata.tabs.reserves(filename),
+            readOnly: cd.kata.tabs.reserves(filename) || !cd.kata.isLatest(),
              tabSize: cd.kata.editor.tabSize(),
          lineNumbers: true,
        matchBrackets: true,

--- a/source/app/views/kata/_download.erb
+++ b/source/app/views/kata/_download.erb
@@ -15,7 +15,7 @@ $(() => {
 
   cd.createTip($button, tip);
 
-  if (cd.kata.manifest().version < 2) {
+  if (!cd.kata.isLatest()) {
     $button.hide();
   } 
   else {

--- a/source/app/views/kata/_file_create_rename_delete.erb
+++ b/source/app/views/kata/_file_create_rename_delete.erb
@@ -28,6 +28,12 @@ $(() => {
   cd.deleteFileButton().click(() => openDeleteFileDialog());
   cd.renameFileButton().click(() => openRenameFileDialog());
 
+  if (!cd.kata.isLatest()) {
+    cd.createFileButton().prop('disabled', true);
+    cd.deleteFileButton().prop('disabled', true);
+    cd.renameFileButton().prop('disabled', true);
+  }
+
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   const openCreateFileDialog = () => {

--- a/source/app/views/kata/_filenames.erb
+++ b/source/app/views/kata/_filenames.erb
@@ -72,7 +72,7 @@ $(() => {
     $filename.addClass('selected');
     cd.kata.tabs.setFilename(filename);
     
-    const disabled = (filename === 'cyber-dojo.sh');
+    const disabled = (filename === 'cyber-dojo.sh') || !cd.kata.isLatest();
     cd.deleteFileButton().attr('disabled', disabled);
     cd.renameFileButton().attr('disabled', disabled);
   };

--- a/source/app/views/kata/_predict_revert.erb
+++ b/source/app/views/kata/_predict_revert.erb
@@ -74,7 +74,12 @@ $(() => {
   $predict.prop('checked', settings.predict() === 'on')
           .click(() => predictCheckBoxChanged());
 
+  if (!cd.kata.isLatest()) {
+    $predict.prop('disabled', true);
+  }
+
   const predictCheckBoxChanged = () => {
+    if (!cd.kata.isLatest()) { return; }
     cd.saveAnyFileChangesITE(() => {
       if ($predict.prop('checked')) {
         predictOn();

--- a/source/app/views/kata/_test_button.erb
+++ b/source/app/views/kata/_test_button.erb
@@ -25,8 +25,16 @@ $(() => {
     }
   };
 
-  const  enableTestButton = () => $button.attr('disabled', false);
-  const disableTestButton = () => $button.attr('disabled', true );
+  const  enableTestButton = () => {
+    if (cd.kata.isLatest()) {
+      $button.attr('disabled', false);
+    }
+  };
+  const disableTestButton = () => $button.attr('disabled', true);
+
+  if (!cd.kata.isLatest()) {
+    disableTestButton();
+  }
 
 });
 </script>

--- a/source/app/views/layouts/application.erb
+++ b/source/app/views/layouts/application.erb
@@ -19,6 +19,7 @@
         kata: {
           id: "<%= @id %>",
           manifest: () => (<%= @manifest.to_json %>),
+          isLatest: () => cyberDojo.kata.manifest().version === 2,
           filenames:{},
           tabs:{}
         },

--- a/source/app/views/review/_checkout_button.erb
+++ b/source/app/views/review/_checkout_button.erb
@@ -24,12 +24,15 @@ $(() => {
     disable: () => $button.prop('disabled', true),
     refresh: () => {
       refreshToolTip();
-      if (review.isFromDashboardPage()) {
+      if (!cd.kata.isLatest()) {
+        review.checkoutButton.disable();
+      }
+      else if (review.isFromDashboardPage()) {
         review.checkoutButton.disable();
       }
       else if (review.isOnFileEvent()) {
         review.checkoutButton.disable();
-      } 
+      }
       else if (kata.id == review.id) {
         review.checkoutButton.disable();
       }

--- a/source/app/views/review/_revert_button.erb
+++ b/source/app/views/review/_revert_button.erb
@@ -40,12 +40,15 @@ $(() => {
     disable: () => $button.prop('disabled', true),
     refresh: () => {
       refreshToolTip();
-      if (review.isFromDashboardPage()) {
+      if (!cd.kata.isLatest()) {
+        review.revertButton.disable();
+      }
+      else if (review.isFromDashboardPage()) {
         review.revertButton.disable();
       }
       else if (review.isOnFileEvent()) {
         review.revertButton.disable();
-      } 
+      }
       else if (kata.id != review.id) {
         review.revertButton.disable();
       }


### PR DESCRIPTION
In preparation for removing the v0/v1 write paths from saver, the editing UI is disabled for those katas: the [test] button, CodeMirror editors, file create/rename/delete buttons, predict checkbox, and review revert/checkout buttons.

Adds cd.kata.isLatest() to centralise the version check, and extends make demo with a v= parameter for testing (e.g. make demo v=0).