### PR TITLE
Make read-only UI controls visible-but-disabled in v0/v1 katas

### DIFF
--- a/source/app/assets/stylesheets/file_create_delete_rename.scss
+++ b/source/app/assets/stylesheets/file_create_delete_rename.scss
@@ -16,8 +16,8 @@
     font-size: 14px;
     background: lighten($darker-color,50%);
     border: 2px solid lighten($darker-color,50%);
-    &:hover { border: 2px dotted lighten(Black,10%); }
-    &[disabled] { display: none; }
+    &:not([disabled]):hover { border: 2px dotted lighten(Black,10%); }
+    &[disabled] { opacity: 0.35; cursor: not-allowed; }
   }
 
   .rename-file img

--- a/source/app/assets/stylesheets/predict-checkbox.scss
+++ b/source/app/assets/stylesheets/predict-checkbox.scss
@@ -31,3 +31,10 @@
   position: relative;
   top: -1px;
 }
+
+#predict-checkbox-cell:has(#predict-checkbox:disabled)
+{
+  opacity: 0.35;
+  #predict-checkbox-title { cursor: not-allowed; }
+  #predict-checkbox { cursor: not-allowed; }
+}

--- a/source/app/assets/stylesheets/test-button.scss
+++ b/source/app/assets/stylesheets/test-button.scss
@@ -15,5 +15,6 @@
   text-align: center;
   font-weight: bold;
   letter-spacing: 0.03em;
-  &:hover { border: 2px dotted Black; }
+  &:not([disabled]):hover { border: 2px dotted Black; }
+  &[disabled] { opacity: 0.35; cursor: not-allowed; }
 }

--- a/source/app/views/kata/_filenames.erb
+++ b/source/app/views/kata/_filenames.erb
@@ -72,9 +72,11 @@ $(() => {
     $filename.addClass('selected');
     cd.kata.tabs.setFilename(filename);
     
-    const disabled = (filename === 'cyber-dojo.sh') || !cd.kata.isLatest();
-    cd.deleteFileButton().attr('disabled', disabled);
-    cd.renameFileButton().attr('disabled', disabled);
+    if (cd.kata.isLatest()) {
+      const isCyberDojoSh = filename === 'cyber-dojo.sh';
+      cd.deleteFileButton().attr('disabled', isCyberDojoSh);
+      cd.renameFileButton().attr('disabled', isCyberDojoSh);
+    }
   };
 
   filenames.unselectAll = () => {

--- a/source/app/views/kata/_predict_revert.erb
+++ b/source/app/views/kata/_predict_revert.erb
@@ -58,13 +58,15 @@ $(() => {
     ].join('');
   };
 
-  cd.createTip($predictCell, [
-    '<table>',
-      colourTr(  'red', 'some tests will fail'),
-      colourTr('amber', 'tests will not run'  ),
-      colourTr('green', 'all tests will pass' ),
-    '</table>'
-    ].join(''));
+  if (cd.kata.isLatest()) {
+    cd.createTip($predictCell, [
+      '<table>',
+        colourTr(  'red', 'some tests will fail'),
+        colourTr('amber', 'tests will not run'  ),
+        colourTr('green', 'all tests will pass' ),
+      '</table>'
+      ].join(''));
+  }
 
   $('#predict-checkbox-title').click(() => {
     $predict.prop('checked', !$predict.is(':checked'));


### PR DESCRIPTION
Previously the file create/delete/rename buttons were hidden when in a v0 or v1 kata. Now all three are always visible, but clearly disabled (opacity 0.35, not-allowed cursor) in v0/v1 katas. In a v2 kata, delete and rename are disabled when cyber-dojo.sh is selected.

The test button and predict checkbox follow the same pattern: visible but dimmed in v0/v1 katas, with no tooltip shown on predict.