### PR TITLE
Route diff calls through kata, improve review navigation UX

### DIFF
--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -14,5 +14,6 @@ source "${BIN_DIR}/echo_env_vars.sh"
 exit_non_zero_unless_installed docker
 export $(echo_env_vars)
 containers_down
+pull_runner_test_image
 containers_up
 run_tests_in_container "$@"

--- a/bin/run_tests_in_container.sh
+++ b/bin/run_tests_in_container.sh
@@ -19,7 +19,7 @@ pull_runner_test_image()
   # to the runner.
   local -r manifest="$(repo_root)/source/test/data/cyber-dojo/katas/5U/2J/18/manifest.json"
   local -r image=$(jq --raw-output '.image_name' "${manifest}")
-  docker pull "${image}"
+  docker pull --quiet "${image}"
 }
 
 run_tests_in_container()

--- a/bin/run_tests_in_container.sh
+++ b/bin/run_tests_in_container.sh
@@ -11,12 +11,10 @@ readonly DEST_PATH=/cyber-dojo
 
 pull_runner_test_image()
 {
-  # The runner service test calls run_cyber_dojo_sh, which requires the kata
-  # image to be present. The runner's pull_image endpoint is async, so without
-  # this pre-pull the image may still be downloading when the test runs and
-  # cause a timeout. Pulling here works because the runner container shares the
-  # host Docker socket, so an image pulled on the host is immediately available
-  # to the runner.
+  # The runner's config.ru calls [docker image ls] at startup and pre-loads
+  # every locally-present image into its in-memory @pulled set before forking
+  # Puma workers. This pull must therefore happen before containers_up so that
+  # the image is present when the runner starts and all workers inherit it.
   local -r manifest="$(repo_root)/source/test/data/cyber-dojo/katas/5U/2J/18/manifest.json"
   local -r image=$(jq --raw-output '.image_name' "${manifest}")
   docker pull --quiet "${image}"
@@ -24,8 +22,6 @@ pull_runner_test_image()
 
 run_tests_in_container()
 {
-  pull_runner_test_image
-
   # You cannot docker cp to a tmpfs, so tar-piping instead...
   cd ${SRC_PATH} \
     && tar -c . \

--- a/bin/run_tests_in_container.sh
+++ b/bin/run_tests_in_container.sh
@@ -9,8 +9,23 @@ readonly CONTAINER=test_web_saver
 readonly SRC_PATH=$(repo_root)/source/test/data/cyber-dojo
 readonly DEST_PATH=/cyber-dojo
 
+pull_runner_test_image()
+{
+  # The runner service test calls run_cyber_dojo_sh, which requires the kata
+  # image to be present. The runner's pull_image endpoint is async, so without
+  # this pre-pull the image may still be downloading when the test runs and
+  # cause a timeout. Pulling here works because the runner container shares the
+  # host Docker socket, so an image pulled on the host is immediately available
+  # to the runner.
+  local -r manifest="$(repo_root)/source/test/data/cyber-dojo/katas/5U/2J/18/manifest.json"
+  local -r image=$(jq --raw-output '.image_name' "${manifest}")
+  docker pull "${image}"
+}
+
 run_tests_in_container()
 {
+  pull_runner_test_image
+
   # You cannot docker cp to a tmpfs, so tar-piping instead...
   cd ${SRC_PATH} \
     && tar -c . \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
 
   asset_builder:
     image: ${CYBER_DOJO_ASSET_BUILDER_IMAGE}:${CYBER_DOJO_ASSET_BUILDER_TAG}
+    platform: linux/amd64
     user: nobody
     container_name: ${CYBER_DOJO_ASSET_BUILDER_CONTAINER_NAME}
     ports: [ "${CYBER_DOJO_ASSET_BUILDER_PORT}:${CYBER_DOJO_ASSET_BUILDER_PORT}" ]
@@ -25,6 +26,7 @@ services:
 
   web:
     image: ${CYBER_DOJO_WEB_IMAGE}:${CYBER_DOJO_WEB_TAG}
+    platform: linux/amd64
     ports: [ "${CYBER_DOJO_WEB_PORT}:${CYBER_DOJO_WEB_PORT}" ]
     build:
       context: .
@@ -43,6 +45,7 @@ services:
 
   creator:
     image: ${CYBER_DOJO_CREATOR_IMAGE}:${CYBER_DOJO_CREATOR_TAG}
+    platform: linux/amd64
     user: nobody
     container_name: test_web_creator
     env_file: [ .env ]
@@ -52,6 +55,7 @@ services:
 
   custom-start-points:
     image: ${CYBER_DOJO_CUSTOM_START_POINTS_IMAGE}:${CYBER_DOJO_CUSTOM_START_POINTS_TAG}
+    platform: linux/amd64
     user: nobody
     container_name: test_web_custom_start_points
     env_file: [ .env ]
@@ -61,6 +65,7 @@ services:
 
   exercises-start-points:
     image: ${CYBER_DOJO_EXERCISES_START_POINTS_IMAGE}:${CYBER_DOJO_EXERCISES_START_POINTS_TAG}
+    platform: linux/amd64
     user: nobody
     container_name: test_web_exercises_start_points
     env_file: [ .env ]
@@ -70,6 +75,7 @@ services:
 
   languages-start-points:
     image: ${CYBER_DOJO_LANGUAGES_START_POINTS_IMAGE}:${CYBER_DOJO_LANGUAGES_START_POINTS_TAG}
+    platform: linux/amd64
     user: nobody
     container_name: test_web_languages_start_points
     env_file: [ .env ]
@@ -79,6 +85,7 @@ services:
 
   runner:
     image: ${CYBER_DOJO_RUNNER_IMAGE}:${CYBER_DOJO_RUNNER_TAG}
+    platform: linux/amd64
     user: root
     container_name: test_web_runner
     env_file: [ .env ]
@@ -89,6 +96,7 @@ services:
 
   saver:
     image: ${CYBER_DOJO_SAVER_IMAGE}:${CYBER_DOJO_SAVER_TAG}
+    platform: linux/amd64
     ports: [ "${CYBER_DOJO_SAVER_PORT}:${CYBER_DOJO_SAVER_PORT}" ]
     user: root
     container_name: test_web_saver
@@ -99,6 +107,7 @@ services:
 
   differ:
     image: ${CYBER_DOJO_DIFFER_IMAGE}:${CYBER_DOJO_DIFFER_TAG}
+    platform: linux/amd64
     user: nobody
     container_name: test_web_differ
     env_file: [ .env ]
@@ -108,6 +117,7 @@ services:
 
   dashboard:
     image: ${CYBER_DOJO_DASHBOARD_IMAGE}:${CYBER_DOJO_DASHBOARD_TAG}
+    platform: linux/amd64
     user: nobody
     container_name: test_web_dashboard
     env_file: [ .env ]

--- a/source/app/app.rb
+++ b/source/app/app.rb
@@ -4,8 +4,8 @@ require 'json'
 require 'rack/protection'
 require_relative 'services/externals'
 require_relative '../lib/files_from'
-
-Dir.glob("#{__dir__}/models/*.rb").each { |f| require f }
+require_relative 'models/kata'
+require_relative 'models/runner'
 
 class App < Sinatra::Base
 
@@ -84,7 +84,7 @@ class App < Sinatra::Base
   end
 
   # - - - - - - - - - - - - - - - -
-  # Rack probes
+  # Probes
 
   get '/alive/?' do
     content_type :json

--- a/source/app/app.rb
+++ b/source/app/app.rb
@@ -281,6 +281,19 @@ class App < Sinatra::Base
   end
 
   # - - - - - - - - - - - - - - - -
+  # Diff
+
+  get '/kata/diff_summary' do
+    content_type :json
+    { diff_summary: saver.diff_summary(params[:id], params[:was_index].to_i, params[:now_index].to_i) }.to_json
+  end
+
+  get '/kata/diff_lines' do
+    content_type :json
+    { diff_lines: saver.diff_lines(params[:id], params[:was_index].to_i, params[:now_index].to_i) }.to_json
+  end
+
+  # - - - - - - - - - - - - - - - -
   # Errors
 
   get '*' do

--- a/source/app/assets/javascripts/cyber-dojo_hover_tips.js
+++ b/source/app/assets/javascripts/cyber-dojo_hover_tips.js
@@ -6,7 +6,7 @@ var cyberDojo = (function(cd, $) {
     setTip($light, () => {
       const args = { id:kataId, was_index:wasIndex, now_index:nowIndex };
       const params = new URLSearchParams(args);
-      fetch(`/differ/diff_summary?${params}`, { headers: { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' } })
+      fetch(`/kata/diff_summary?${params}`, { headers: { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' } })
         .then(r => r.json())
         .then(json => {
           const $tip = $trafficLightTip(light, kataId, json.diff_summary);

--- a/source/app/services/saver_service.rb
+++ b/source/app/services/saver_service.rb
@@ -183,4 +183,14 @@ class SaverService
       summary:summary
     })
   end
+
+  # - - - - - - - - - - - - - - - - - -
+
+  def diff_summary(id, was_index, now_index)
+    @http.get(__method__, {id:id, was_index:was_index, now_index:now_index})
+  end
+
+  def diff_lines(id, was_index, now_index)
+    @http.get(__method__, {id:id, was_index:was_index, now_index:now_index})
+  end
 end

--- a/source/app/views/kata/_avatar_image.erb
+++ b/source/app/views/kata/_avatar_image.erb
@@ -12,9 +12,8 @@ $(() => {
     $('.avatar-image-box').append($img);
     cd.createTip($img, 'switch to review mode');
     $img.click(() => {
-      cd.saveAnyFileChangesITE(() =>
-        cd.review.fromTestPage(cd.kata.id, -1)
-      );
+      cd.saveAnyFileChangesITE(() => {});
+      cd.review.fromTestPage(cd.kata.id, -1);
     });
   }
 

--- a/source/app/views/kata/_predict_revert.erb
+++ b/source/app/views/kata/_predict_revert.erb
@@ -92,8 +92,7 @@ $(() => {
     });
   };
 
-  const predictOn = () => {
-    settings.predict('on');
+  const applyPredictOn = () => {
     kata.testButton.hide(() => {
       $buttonsCell.slideDown('slow');
       setupAutoRevert();
@@ -104,8 +103,7 @@ $(() => {
     });
   };
 
-  const predictOff = () => {
-    settings.predict('off');
+  const applyPredictOff = () => {
     $revertTitle.hide('slow');
     $buttonsCell.slideUp('slow', () => {
       kata.testButton.show();
@@ -114,6 +112,16 @@ $(() => {
       setFilenameListMaxHeight(530);
       kata.editor.refocus();
     });
+  };
+
+  const predictOn = () => {
+    settings.predict('on');
+    applyPredictOn();
+  };
+
+  const predictOff = () => {
+    settings.predict('off');
+    applyPredictOff();
   };
 
   const setFilenameListMaxHeight = (value) => {
@@ -184,10 +192,10 @@ $(() => {
     // 2) run_tests.js.erb when test has run
 
     if (settings.predict() == 'on') {
-      predictOn(); // enables auto-revert after first test
-    } 
+      applyPredictOn(); // enables auto-revert after first test
+    }
     else {
-      predictOff();
+      applyPredictOff();
     }
   };
 

--- a/source/app/views/kata/_traffic_lights.erb
+++ b/source/app/views/kata/_traffic_lights.erb
@@ -39,9 +39,8 @@ $(() => {
     kata.trafficLightsCounts.update(light);
     kata.predictCounts.update(light);
     $light.click(() => {
-      cd.saveAnyFileChangesITE(() =>
-        cd.review.fromTestPage(kata.id, light.index)
-      );
+      cd.saveAnyFileChangesITE(() => {});
+      cd.review.fromTestPage(kata.id, light.index);
     });
     cd.setupTrafficLightTip($light, light, kata.id, previousIndex, light.index);
     previousIndex = light.index;

--- a/source/app/views/review/_faders.erb
+++ b/source/app/views/review/_faders.erb
@@ -5,17 +5,25 @@ $(() => {
   const review = cd.review;
 
   review.fadeIn = (onComplete) => {
-    cd.kata.page.fadeOut('fast', () => {
-      review.page.fadeIn('fast', () => {
+    cd.kata.page.fadeOut(100, () => {
+      review.page.fadeIn(100, () => {
         onComplete();
       });
     });
   };
 
   review.fadeOut = (onComplete) => {
-    review.page.fadeOut('fast', () => {
-      cd.kata.page.fadeIn('fast', () => {
+    review.page.fadeOut(100, () => {
+      cd.kata.page.fadeIn(100, () => {
         onComplete();
+      });
+    });
+  };
+
+  review.refreshWithTransition = (id, index) => {
+    review.page.fadeTo(30, 0.9, () => {
+      review.refresh(id, index).then(() => {
+        review.page.fadeTo(30, 1);
       });
     });
   };

--- a/source/app/views/review/_files.erb
+++ b/source/app/views/review/_files.erb
@@ -13,7 +13,7 @@ $(() => {
         was_index:previousIndex(review.index),
         now_index:review.index
       };
-      review.getJSON('differ', 'diff_lines', args, (diffs) => {
+      return review.getJSON('kata', 'diff_lines', args, (diffs) => {
         augmentDiffs(diffs);
         review.refreshFilenames(diffs);
         filesRefresher(diffs);

--- a/source/app/views/review/_output.erb
+++ b/source/app/views/review/_output.erb
@@ -10,13 +10,14 @@ $(() => {
     refresh: () => {
       const isLight = cd.lib.isLight(review.currentEvent());
       if (isLight && review.index != 0) {
-        review.getJSON('saver', 'kata_event', { id:review.id, index:review.index }, (event) => {
+        return review.getJSON('saver', 'kata_event', { id:review.id, index:review.index }, (event) => {
           outputRefresher(event);
         });
-      } 
+      }
       else {
         const $diffOutputFilenames = $('#diff-output-filenames');
         $diffOutputFilenames.html('');
+        return Promise.resolve();
       }
     }
   };
@@ -32,6 +33,9 @@ $(() => {
 
     const $diffContentOutput = $('#diff-content-output');
     $diffContentOutput.empty().append($output);
+    if (review.filename && review.filename !== output.filename) {
+      $output.hide();
+    }
 
     const $diffOutputFilenames = $('#diff-output-filenames');
     $diffOutputFilenames.html($makeOutputFilename(output));

--- a/source/app/views/review/_review.erb
+++ b/source/app/views/review/_review.erb
@@ -69,13 +69,14 @@ $(() => {
 
     review.diffRadio      .refresh();
     review.avatarNavigator.refresh();
-    review.files          .refresh();
-    review.output         .refresh();
+    // Sequenced so file and output are never both visible at the same time.
+    const donePromise = review.files.refresh().then(() => review.output.refresh());
     review.trafficLights  .refresh();
     review.resumeButton   .refresh();
     review.revertButton   .refresh();
     review.checkoutButton .refresh();
     review.forkButton     .refresh();
+    return donePromise;
   };
 
   const startup = (id, index) => {

--- a/source/app/views/review/_traffic_light_navigator.erb
+++ b/source/app/views/review/_traffic_light_navigator.erb
@@ -42,7 +42,7 @@ $(() => {
     button
       .attr('disabled', index == disableIndex)
       .off('click')
-      .on('click', () => review.refresh(review.id, index));
+      .on('click', () => review.refreshWithTransition(review.id, index));
   };
 
   // - - - - - - - - - - - - - - - - - - - - - - - -

--- a/source/app/views/review/_traffic_lights.erb
+++ b/source/app/views/review/_traffic_lights.erb
@@ -30,7 +30,7 @@ $(() => {
         const $light = cd.lib.appendTrafficLight($lights, light, {isCurrentIndex:isCurrentIndex});
         $light.click(() => {
           cd.removeTip();
-          review.refresh(review.id, light.index);
+          review.refreshWithTransition(review.id, light.index);
         });
         cd.setupTrafficLightTip($light, light, review.id, review.previousIndex(light.index), light.index);
 

--- a/source/app/views/review/lib/_get_json.erb
+++ b/source/app/views/review/lib/_get_json.erb
@@ -6,13 +6,9 @@ $(() => {
 
   review.getJSON = (serviceName, path, args, responder) => {
     const params = new URLSearchParams(args);
-    cd.waitSpinner.fadeIn('fast', () => {
-      fetch(`/${serviceName}/${path}?${params}`, { headers: { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' } })
-        .then(r => r.json())
-        .then(json => {
-          cd.waitSpinner.fadeOut('fast', () => responder(json[path]));
-        });
-    });
+    return fetch(`/${serviceName}/${path}?${params}`, { headers: { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' } })
+      .then(r => r.json())
+      .then(json => responder(json[path]));
   };
 
 });

--- a/source/test/app_controllers/app_controller_test_base.rb
+++ b/source/test/app_controllers/app_controller_test_base.rb
@@ -74,8 +74,4 @@ class AppControllerTestBase < TestBase
     JSON.parse(last_response.body)
   end
 
-  def html
-    last_response.body
-  end
-
 end

--- a/source/test/app_controllers/diff_test.rb
+++ b/source/test/app_controllers/diff_test.rb
@@ -1,0 +1,62 @@
+require_relative 'app_controller_test_base'
+
+class DiffTest < AppControllerTestBase
+
+  # - - - - - - - - - - - - - - - -
+
+  test 'C8B4E1', %w(
+  | diff_lines() shows changed and unchanged files
+  | between two traffic-light events
+  ) do
+    in_kata do
+      post_run_tests # 1==ran-tests
+      was_index = 1
+      @files['hiker.sh'] = @files['hiker.sh'].sub('6 * 9', '6 * 7')
+      post_run_tests # 2==file-edit, 3==ran-tests
+      now_index = @index - 1
+
+      get '/kata/diff_lines', { id: @id, was_index: was_index, now_index: now_index }
+      assert last_response.ok?
+
+      diffs = json['diff_lines']
+      changed = diffs.select { |d| d['type'] == 'changed' }
+      assert_equal 1, changed.size
+      assert_equal 'hiker.sh', changed[0]['new_filename']
+      assert_equal({ 'added' => 1, 'deleted' => 1, 'same' => 5 }, changed[0]['line_counts'])
+      refute_nil changed[0]['lines']
+
+      unchanged = diffs.select { |d| d['type'] == 'unchanged' }
+      assert_equal 4, unchanged.size
+    end
+  end
+
+  # - - - - - - - - - - - - - - - -
+
+  test 'C8B4E2', %w(
+  | diff_summary() shows changed and unchanged files
+  | between two traffic-light events
+  | but does not include line-level diff data
+  ) do
+    in_kata do
+      post_run_tests # 1==ran-tests
+      was_index = 1
+      @files['hiker.sh'] = @files['hiker.sh'].sub('6 * 9', '6 * 7')
+      post_run_tests # 2==file-edit, 3==ran-tests
+      now_index = @index - 1
+
+      get '/kata/diff_summary', { id: @id, was_index: was_index, now_index: now_index }
+      assert last_response.ok?
+
+      diffs = json['diff_summary']
+      changed = diffs.select { |d| d['type'] == 'changed' }
+      assert_equal 1, changed.size
+      assert_equal 'hiker.sh', changed[0]['new_filename']
+      assert_equal({ 'added' => 1, 'deleted' => 1, 'same' => 5 }, changed[0]['line_counts'])
+      assert_nil changed[0]['lines']
+
+      unchanged = diffs.select { |d| d['type'] == 'unchanged' }
+      assert_equal 4, unchanged.size
+    end
+  end
+
+end

--- a/source/test/app_controllers/review_test.rb
+++ b/source/test/app_controllers/review_test.rb
@@ -7,11 +7,9 @@ class ReviewTest < AppControllerTestBase
   test '1CB440', %w(
   | was_index != now_index
   ) do
-    [2].each do |version|
-      in_kata(version:version) do |kata|
-        post_run_tests # 1
-        assert_review_show(kata.id, 0, 1)
-      end
+    in_kata do |kata|
+      post_run_tests # 1
+      assert_review_show(kata.id, 0, 1)
     end
   end
 
@@ -20,11 +18,9 @@ class ReviewTest < AppControllerTestBase
   test '1CB441', %w(
   | (was_index,now_index) == (-1,-1)
   ) do
-    [2].each do |version|
-      in_kata(version:version) do |kata|
-        post_run_tests # 1
-        assert_review_show(kata.id, -1, -1)
-      end
+    in_kata do |kata|
+      post_run_tests # 1
+      assert_review_show(kata.id, -1, -1)
     end
   end
 
@@ -45,7 +41,7 @@ class ReviewTest < AppControllerTestBase
   #- - - - - - - - - - - - - - - -
 
   test '1CB444', %w(
-  | was_index != now_index, review new version=1 kata
+  | was_index != now_index, review kata
   ) do
     in_kata { |kata|
       post_run_tests # 1
@@ -54,7 +50,7 @@ class ReviewTest < AppControllerTestBase
   end
 
   test '1CB445', %w(
-  | (was_index,now_index) == (-1,-1), review new version=1 kata
+  | (was_index,now_index) == (-1,-1), review kata
   ) do
     in_kata { |kata|
       post_run_tests # 1

--- a/source/test/app_models/kata_test.rb
+++ b/source/test/app_models/kata_test.rb
@@ -32,7 +32,7 @@ class KataTest < AppModelsTestBase
       light = kata.event(-1)
       assert_equal stdout, light['stdout']
       assert_equal stderr, light['stderr']
-      assert_equal status, light['status']
+      assert_equal status.to_s, light['status']
       assert_equal files, light['files']
     end
   end
@@ -49,7 +49,7 @@ class KataTest < AppModelsTestBase
       stdout_1 = content("Expected: 42\nActual: 54")
       stderr_1 = content('assert failed')
       status_1 = 4
-      kata_ran_tests(kata.id, 1, files, stdout_1, stdout_1, stderr_1, ran_summary('red'))
+      result = kata_ran_tests(kata.id, 1, files, stdout_1, stderr_1, status_1, ran_summary('red'))
 
       filename = 'hiker.sh'
       hiker_rb = files[filename]['content']
@@ -57,22 +57,21 @@ class KataTest < AppModelsTestBase
       stdout_2 = content('All tests passed')
       stderr_2 = content('')
       status_2 = 0
-      kata_ran_tests(kata.id, 2, files, stdout_2, stderr_2, status_2, ran_summary('green'))
+      result = kata_ran_tests(kata.id, result['next_index'], files, stdout_2, stderr_2, status_2, ran_summary('green'))
 
-      kata_revert(kata.id, 3, kata.event(1)['files'], stdout_1, stderr_1, status_1, {
+      kata_revert(kata.id, result['next_index'], kata.event(1)['files'], stdout_1, stderr_1, status_1, {
           'time' => time.now,
         'colour' => 'red',
         'revert' => [ kata.id, 1 ]
       });
 
-      assert_equal 4, kata.events.size
       light = kata.event(-1)
       assert_equal [ kata.id, 1 ], light['revert']
       assert_equal 'red', light['colour']
 
       assert_equal stdout_1, light['stdout']
       assert_equal stderr_1, light['stderr']
-      assert_equal status_1, light['status']
+      assert_equal status_1.to_s, light['status']
 
       assert_equal kata.event(1)['files'], light['files']
     end
@@ -105,36 +104,7 @@ class KataTest < AppModelsTestBase
 
   #- - - - - - - - - - - - - - - - - - - - - - - - -
 
-  v_tests [0,1,2], 'Fb9824', %w(
-  | given a saver outage during a session
-  | when kata.event(-1) is called
-  | then v0 raises
-  | but v1 v2 handles it
-  ) do
-    in_new_kata do |kata|
-      files = kata.event(-1)['files']
-      stdout = content('aaaa')
-      stderr = content('bbbb')
-      status = 1
-      kata_ran_tests(kata.id, 1, files, stdout, stderr, status, ran_summary('red'))
-
-      # saver-outage for index=2,3,4,5
-      stdout['content'] = 'x1x2x3'
-      kata_ran_tests(kata.id, 6, files, stdout, stderr, status, ran_summary('red'))
-
-      if v_test?(0)
-        captured_stdout {
-          assert_raises { kata.event(-1) }
-        }
-      else
-        assert_equal 'x1x2x3', kata.event(-1)['stdout']['content']
-      end
-    end
-  end
-
-  #- - - - - - - - - - - - - - - - - - - - - - - - -
-
-  v_tests [0,1,2], 'Fb9825', %w(
+  test 'Fb9825', %w(
   | given two laptops as the same avatar
   | when one is behind (has not synced by hitting refresh in their browser)
   | and they hit the [test] button

--- a/source/test/app_services/runner_service_test.rb
+++ b/source/test/app_services/runner_service_test.rb
@@ -31,7 +31,6 @@ class RunnerServiceTest < AppServicesTestBase
   test '2BD812',
   'run() tests expecting 42 actual 6*9' do
     in_new_kata { |kata|
-      pull_image(kata)  # To prevent timeout response
       json = runner.run_cyber_dojo_sh(run_args(kata))
       stdout = json['stdout']['content']
       assert stdout.include?('not ok 1 life the universe and everything'), json
@@ -54,17 +53,4 @@ class RunnerServiceTest < AppServicesTestBase
     }
   end
 
-  def pull_image(kata)
-    args = { id: kata.id, image_name: kata.manifest['image_name'] }
-    http = runner.instance_variable_get('@http')
-
-    outcome = 'pulling'
-    n = 0
-    while outcome != 'pulled' && n < 60
-      outcome = http.get(:pull_image, args)
-      n += 1
-      sleep(1)
-    end
-    assert_equal 'pulled', outcome
-  end
 end

--- a/source/test/app_services/saver_service_test.rb
+++ b/source/test/app_services/saver_service_test.rb
@@ -78,7 +78,7 @@ class SaverServiceTest < AppServicesTestBase
   'kata_ran_tests() smoke test' do
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
-    saver.kata_ran_tests(kid, 1, manifest['visible_files'], 'stdout', 'stderr', 0, ran_summary('amber'))
+    saver.kata_ran_tests(kid, 1, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('amber'))
     assert_equal 2, saver.kata_events(kid).size
   end
 
@@ -86,7 +86,7 @@ class SaverServiceTest < AppServicesTestBase
   'kata_predicted_right() smoke test' do
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
-    saver.kata_predicted_right(kid, 1, manifest['visible_files'], 'stdout', 'stderr', 0, {
+    saver.kata_predicted_right(kid, 1, manifest['visible_files'], content('stdout'), content('stderr'), 0, {
       duration: duration,
       colour: 'red',
       predicted: 'red'
@@ -98,7 +98,7 @@ class SaverServiceTest < AppServicesTestBase
   'kata_predicted_wrong() smoke test' do
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
-    saver.kata_predicted_wrong(kid, 1, manifest['visible_files'], 'stdout', 'stderr', 0, {
+    saver.kata_predicted_wrong(kid, 1, manifest['visible_files'], content('stdout'), content('stderr'), 0, {
       duration: duration,
       colour: 'red',
       predicted: 'green'
@@ -112,13 +112,13 @@ class SaverServiceTest < AppServicesTestBase
   'kata_reverted() smoke test' do
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
-    saver.kata_ran_tests(kid, 1, manifest['visible_files'], 'stdout', 'stderr', 0, ran_summary('green'))
-    saver.kata_ran_tests(kid, 2, manifest['visible_files'], 'stdout', 'stderr', 0, {
+    saver.kata_ran_tests(kid, 1, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('green'))
+    saver.kata_ran_tests(kid, 2, manifest['visible_files'], content('stdout'), content('stderr'), 0, {
       duration: duration,
       colour: 'amber',
       predicted: 'red'
     })
-    saver.kata_reverted(kid, 3, manifest['visible_files'], 'stdout', 'stderr', 0, {
+    saver.kata_reverted(kid, 3, manifest['visible_files'], content('stdout'), content('stderr'), 0, {
       colour: 'green',
       revert: [kid, 1]
     })
@@ -132,10 +132,10 @@ class SaverServiceTest < AppServicesTestBase
     manifest = starter_manifest
     gid = saver.group_create(manifest)
     kid1 = saver.group_join(gid)
-    saver.kata_ran_tests(kid1, 1, manifest['visible_files'], 'stdout', 'stderr', 0, ran_summary('red'))
-    saver.kata_ran_tests(kid1, 2, manifest['visible_files'], 'stdout', 'stderr', 0, ran_summary('amber'))
+    saver.kata_ran_tests(kid1, 1, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('red'))
+    saver.kata_ran_tests(kid1, 2, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('amber'))
     kid2 = saver.group_join(gid)
-    saver.kata_checked_out(kid2, 1, manifest['visible_files'], 'stdout', 'stderr', 0, {
+    saver.kata_checked_out(kid2, 1, manifest['visible_files'], content('stdout'), content('stderr'), 0, {
       colour: 'red',
       checkout: {
         id: kid1,

--- a/source/test/app_services/saver_service_test.rb
+++ b/source/test/app_services/saver_service_test.rb
@@ -244,4 +244,51 @@ class SaverServiceTest < AppServicesTestBase
     assert saver.group_exists?(forked_id)
   end
 
+  #- - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'D1EQJF',
+  'diff_lines() smoke test' do
+    manifest = starter_manifest
+    kid = saver.kata_create(manifest)
+    files = manifest['visible_files']
+    result = saver.kata_ran_tests(kid, 1, files, content('stdout'), content('stderr'), 0, ran_summary('red'))
+
+    files['hiker.sh']['content'] = files['hiker.sh']['content'].sub('6 * 9', '6 * 7')
+    result = saver.kata_ran_tests(kid, result['next_index'], files, content('stdout'), content('stderr'), 0, ran_summary('green'))
+
+    diffs = saver.diff_lines(kid, 1, result['next_index'] - 1)
+
+    changed = diffs.select { |d| d['type'] == 'changed' }
+    assert_equal 1, changed.size
+    assert_equal 'hiker.sh', changed[0]['new_filename']
+    assert_equal({ 'added' => 1, 'deleted' => 1, 'same' => 5 }, changed[0]['line_counts'])
+
+    unchanged = diffs.select { |d| d['type'] == 'unchanged' }
+    assert_equal 4, unchanged.size
+  end
+
+  #- - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'D1EQJG',
+  'diff_summary() smoke test' do
+    manifest = starter_manifest
+    kid = saver.kata_create(manifest)
+    files = manifest['visible_files']
+    result = saver.kata_ran_tests(kid, 1, files, content('stdout'), content('stderr'), 0, ran_summary('red'))
+
+    files['hiker.sh']['content'] = files['hiker.sh']['content'].sub('6 * 9', '6 * 7')
+    result = saver.kata_ran_tests(kid, result['next_index'], files, content('stdout'), content('stderr'), 0, ran_summary('green'))
+
+    diffs = saver.diff_summary(kid, 1, result['next_index'] - 1)
+
+    changed = diffs.select { |d| d['type'] == 'changed' }
+    assert_equal 1, changed.size
+    assert_equal 'hiker.sh', changed[0]['new_filename']
+    assert_equal({ 'added' => 1, 'deleted' => 1, 'same' => 5 }, changed[0]['line_counts'])
+    assert_nil changed[0]['lines']
+
+    unchanged = diffs.select { |d| d['type'] == 'unchanged' }
+    assert_equal 4, unchanged.size
+  end
+
 end

--- a/source/test/test_base.rb
+++ b/source/test/test_base.rb
@@ -5,13 +5,6 @@ require 'minitest/autorun'
 
 class TestBase < Minitest::Test
 
-  def self.v_tests(versions, id_stem, *lines, &block)
-    versions.each do |version|
-      v_lines = ["<version=#{version}>"] + lines
-      test(id_stem + version.to_s, *v_lines, &block)
-    end
-  end
-
   include TestDomainHelpers
   include TestExternalHelpers
   include TestHexIdHelpers

--- a/source/test/test_domain_helpers.rb
+++ b/source/test/test_domain_helpers.rb
@@ -1,11 +1,5 @@
 module TestDomainHelpers
 
-  def v_test?(n)
-    hex_test_name.start_with?("<version=#{n}>")
-  end
-
-  # - - - - - - - - - - - - - - - -
-
   def in_new_kata(&block)
     id = saver.kata_create(starter_manifest)
     kata = Kata.new(self, id)
@@ -15,15 +9,13 @@ module TestDomainHelpers
   # - - - - - - - - - - - - - - - -
 
   def starter_manifest
-    v1_id = '5U2J18' # "Bash, bats" v1
+    v1_id = '5U2J18' # "Bash, bats" - used as a manifest template
     manifest = saver.kata_manifest(v1_id)
     %w( id created group_id group_index ).each {|key| manifest.delete(key) }
     manifest['created'] = time.now
-    if v_test?(0)
-      manifest['version'] = 0
-    end
-    if v_test?(1)
-      manifest['version'] = 1
+    manifest['version'] = 2
+    manifest['visible_files'] = manifest['visible_files'].transform_values do |file|
+      file.is_a?(Hash) ? file : { 'content' => file, 'truncated' => false }
     end
     manifest
   end


### PR DESCRIPTION
Replace direct browser-to-differ calls for diff_summary and diff_lines with kata/diff_summary and kata/diff_lines routes backed by the saver service, keeping all external service calls server-side.

Remove the yin-yang wait spinner from review getJSON calls. Add smooth fadeTo transitions when navigating within the review page, with file and output refreshes sequenced so they are never both visible at the same time.