### PR TITLE
Improve review mode visual design for file type distinction

### DIFF
--- a/source/app/assets/stylesheets/diff-radio.scss
+++ b/source/app/assets/stylesheets/diff-radio.scss
@@ -7,8 +7,9 @@
   color: $lighter-color;
   background: lighten($darker-color,10%);
   padding: 3px;
-  margin: { top:10px; left:13px; } 
-  label 
+  margin: { top:10px; left:13px; }
+  input[type=radio] { accent-color: darkgray; }
+  label
   {
     position: relative;
     top: -3px;

--- a/source/app/assets/stylesheets/diff.scss
+++ b/source/app/assets/stylesheets/diff.scss
@@ -25,24 +25,25 @@
   padding: 2px;
   margin: { left: 2px; right: 2px; }
   text-align: center;
-  $n_dash: '\2013';
+  $m_dash: '\2014';
   $curved_right_arrow: '\21B7';
+  $bullet: '\25CF';
   &.created   { &:before { content: '+'; } }
-  &.deleted   { &:before { content: $n_dash; } }
+  &.deleted   { &:before { content: $m_dash; } }
   &.renamed   { &:before { content: $curved_right_arrow; } }
-  &.changed   { &:before { content: '!'; } }
+  &.changed   { &:before { content: $bullet; } }
   &.unchanged { &:before { content: ' '; } }
 }
 
 .diff-type-marker, .diff-filename
 {
   @include plaintext-font();
-  &.created   { color: lighten($green,15%); }
-  &.deleted   { color: lighten($red,  15%); }
-  &.renamed   { color: lighten($blue, 25%); }
-  &.changed   { color: white; }
-  &.unchanged { color: darken(DarkGray,15%); }
+  &.changed:not(.hover):not(.test-file)   { color: white; }
+  &.unchanged:not(.hover):not(.test-file) { color: darken(DarkGray,15%); }
 }
+
+.diff-filename.test-file          { color: steelblue; }
+.diff-filename.test-file.selected { color: deepskyblue; }
 
 .diff-filename
 {

--- a/source/app/views/kata/_filenames.erb
+++ b/source/app/views/kata/_filenames.erb
@@ -115,6 +115,9 @@ $(() => {
            id: `radio_${filename}`,
          text: filename
     });
+    if (cd.isTestFile(filename)) {
+      $div.css('color', 'steelblue');
+    }
     if (cd.isHighlightFile(filename)) {
       $div.addClass('highlight');
     }

--- a/source/app/views/review/_filenames.erb
+++ b/source/app/views/review/_filenames.erb
@@ -58,7 +58,7 @@ $(() => {
 
   const oldFilenameTip = (diff) => {
     const filename = cd.htmlEscape(diff.old_filename);
-    return `was<span class="diff-filename renamed">${filename}</span>`;
+    return `was <span class="hover diff-filename renamed">${filename}</span>`;
   };
 
   const diffChunkPlural = (count) => {
@@ -71,11 +71,18 @@ $(() => {
 
   // - - - - - - - - - - - - - - - - - - - - - - - -
   review.makeDiffFilename = (diff) => {
-    return $('<div>', {
+    const attrs = {
       class: `diff-filename ${diff.type}`,
          id: `diff-filename-${diff.id}`,
       'data-diff-id': diff.id
-    }).html(diff.filename)
+    };
+    if (cd.isTestFile(diff.filename)) {
+      attrs.class += ' test-file';
+    } else if (diff.type !== 'unchanged') {
+      attrs.style = 'color:white';
+    }
+    return $('<div>', attrs)
+      .html(diff.filename)
       .click(() => review.selectFilename(diff));
   };
 

--- a/source/app/views/review/_output.erb
+++ b/source/app/views/review/_output.erb
@@ -39,6 +39,9 @@ $(() => {
 
     const $diffOutputFilenames = $('#diff-output-filenames');
     $diffOutputFilenames.html($makeOutputFilename(output));
+    if (review.diffRadio.isDetailed()) {
+      review.selectFilename(output);
+    }
   };
 
   const rstrip = (s) => {


### PR DESCRIPTION
- Show test filenames in steel-blue (edit and review modes); deepskyblue when selected
- Use circle (U+25CF) for changed-file marker, em-dash for deleted; restore markers in help dialog
- Auto-select output pseudo-filename in detailed mode
- Fix hover-tip colours: all 5 file types match in help dialog; renamed tip spacing fixed
- Dark-grey accent-colour for diff radio buttons