### PR TITLE
Switch file immediately on click, fire ITE in background

### DIFF
--- a/source/app/views/kata/_filenames.erb
+++ b/source/app/views/kata/_filenames.erb
@@ -122,9 +122,8 @@ $(() => {
       $div.addClass('source');
     }
     $div.click(() => {
-      cd.saveAnyFileChangesITE(() => {
-        filenames.select(filename);
-      });
+      filenames.select(filename);
+      cd.saveAnyFileChangesITE(() => {});
     });
     return $div;
   };


### PR DESCRIPTION
The file_edit inter-test event was recorded before the editor switched, causing a noticeable delay on every filename click. The UI switch does not depend on the server-assigned index, so it is safe to run immediately while the POST fires in parallel.