### PR TITLE
Let multiple demos run concurrently without colliding

### DIFF
--- a/bin/copy_in_saver_test_data.sh
+++ b/bin/copy_in_saver_test_data.sh
@@ -1,7 +1,7 @@
 
 copy_in_saver_test_data()
 {
-  local -r SAVER_CID="$(saver_cid)"
+  local -r SAVER_CID="$(service_container saver)"
   local -r SRC_PATH=$(repo_root)/source/test/data/cyber-dojo
   local -r DEST_PATH=/cyber-dojo
   # Empty the /cyber-dojo dir ready for tar-pipe
@@ -11,9 +11,4 @@ copy_in_saver_test_data()
   cd ${SRC_PATH} \
     && tar -c . \
     | docker exec -i ${SAVER_CID} tar x -C ${DEST_PATH}
-}
-
-saver_cid()
-{
-  docker ps --filter status=running --format '{{.Names}}' | grep "web_saver"
 }

--- a/bin/copy_out_saver_data.sh
+++ b/bin/copy_out_saver_data.sh
@@ -9,9 +9,9 @@ exit_non_zero_unless_installed docker
 
 readonly SRC_DIR=/cyber-dojo
 readonly DST_TGZ_FILENAME="${ROOT_DIR}/saver_data.tgz"
-readonly CONTAINER=test_web_saver
+readonly SAVER_CID="$(service_container saver)"
 
 # extract /cyber-dojo from container into tgz file
-docker exec "${CONTAINER}" \
+docker exec "${SAVER_CID}" \
   tar -zcf - -C $(dirname ${SRC_DIR}) $(basename ${SRC_DIR}) \
     > "${DST_TGZ_FILENAME}"

--- a/bin/create_v2_kata.sh
+++ b/bin/create_v2_kata.sh
@@ -8,6 +8,6 @@ create_v2_kata()
   local count="${1:-1}"
   docker exec \
     --env CYBER_DOJO_SAVER_CLASS=SaverService \
-    test_web \
+    "$(service_container web)" \
     bash -c "ruby /web/source/script/create_v2_kata.rb ${count}"
 }

--- a/bin/demo.sh
+++ b/bin/demo.sh
@@ -14,6 +14,16 @@ source "${BIN_DIR}/lib.sh"
 export DOCKER_DEFAULT_PLATFORM=linux/amd64
 export $(echo_env_vars)
 
+# Each demo runs as its own docker-compose project so several demos (in
+# this repo and in sibling repos) can run at once without their networks,
+# container names or host ports colliding. nginx is the only service
+# published to the host; the backend services talk over the project's
+# private network. Override these two vars to run a second web demo
+# alongside the first, eg:
+#   COMPOSE_PROJECT_NAME=web2 CYBER_DOJO_NGINX_HOST_PORT=81 bin/demo.sh
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-web}"
+export CYBER_DOJO_NGINX_HOST_PORT="${CYBER_DOJO_NGINX_HOST_PORT:-80}"
+
 web_build()
 {
   docker --log-level=ERROR compose \
@@ -36,13 +46,23 @@ up_nginx()
     run \
       --detach \
       --service-ports \
-      --name test_web_nginx \
       nginx
+}
+
+demo_down()
+{
+  # Tear down only this demo's project (COMPOSE_PROJECT_NAME), leaving
+  # any other repo's running demo untouched.
+  docker --log-level=ERROR compose \
+    --file "$(repo_root)/docker-compose-depends.yml" \
+    --file "$(repo_root)/docker-compose-nginx.yml" \
+    --file "$(repo_root)/docker-compose.yml" \
+    down --remove-orphans 2>/dev/null || true
 }
 
 # - - - - - - - - - - - - - - - - - - - - - - -
 exit_non_zero_unless_installed docker
-docker ps -aq | xargs docker rm -f
+demo_down
 web_build
 up_nginx
 readonly COUNT="${1:-1}"
@@ -50,12 +70,12 @@ readonly KATA_VERSION="${2:-2}"
 copy_in_saver_test_data # eg 5U2J18 (v1)  5rTJv5 (v0)
 if [ "${KATA_VERSION}" = "0" ]; then
   echo "v0 Kata ID=5rTJv5"
-  open "http://localhost:80/kata/edit/5rTJv5"
+  open "http://localhost:${CYBER_DOJO_NGINX_HOST_PORT}/kata/edit/5rTJv5"
 elif [ "${KATA_VERSION}" = "1" ]; then
   echo "v1 Kata ID=RNCzUr"
-  open "http://localhost:80/kata/edit/RNCzUr"
+  open "http://localhost:${CYBER_DOJO_NGINX_HOST_PORT}/kata/edit/RNCzUr"
 else
   id="$(create_v2_kata "${COUNT}")"
   echo "v2 Kata ID=${id}"
-  open "http://localhost:80/kata/edit/${id}"
+  open "http://localhost:${CYBER_DOJO_NGINX_HOST_PORT}/kata/edit/${id}"
 fi

--- a/bin/enter_saver.sh
+++ b/bin/enter_saver.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 set -Eeu
 
-docker exec -it test_web_saver bash
+readonly BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${BIN_DIR}/lib.sh"
+
+docker exec -it "$(service_container saver)" bash

--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -31,6 +31,19 @@ installed()
   fi
 }
 
+service_container()
+{
+  # Echo the container id of the given docker-compose service within
+  # this demo's project. The project is COMPOSE_PROJECT_NAME (set by
+  # bin/demo.sh), defaulting to web so the saver/test helpers work
+  # against a plain demo when the var is not exported in the shell.
+  local -r service="${1}"
+  docker ps \
+    --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME:-web}" \
+    --filter "label=com.docker.compose.service=${service}" \
+    --format '{{.ID}}'
+}
+
 stderr()
 {
   >&2 echo "${1}"

--- a/bin/probe_demo.sh
+++ b/bin/probe_demo.sh
@@ -45,7 +45,7 @@ curl_200()
 }
 
 #- - - - - - - - - - - - - - - - - - - - - - - - - - -
-port() { printf 80; }
+port() { printf "${CYBER_DOJO_NGINX_HOST_PORT:-80}"; }
 tab() { printf '\t'; }
 
 #- - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/bin/run_tests_in_container.sh
+++ b/bin/run_tests_in_container.sh
@@ -5,7 +5,6 @@ set -Eeu
 # Copy saver-test-data into saver container
 # Done here to ensure it always happens before tests are run.
 
-readonly CONTAINER=test_web_saver
 readonly SRC_PATH=$(repo_root)/source/test/data/cyber-dojo
 readonly DEST_PATH=/cyber-dojo
 
@@ -22,14 +21,19 @@ pull_runner_test_image()
 
 run_tests_in_container()
 {
+  # Resolved here (not at source-time) because the containers are not up
+  # until run_tests.sh calls containers_up, which happens after this file
+  # is sourced.
+  local -r SAVER_CID="$(service_container saver)"
+
   # You cannot docker cp to a tmpfs, so tar-piping instead...
   cd ${SRC_PATH} \
     && tar -c . \
-    | docker exec -i ${CONTAINER} tar x -C ${DEST_PATH}
+    | docker exec -i ${SAVER_CID} tar x -C ${DEST_PATH}
 
   #- - - - - - - - - - - - - - - - - - - -
   # Now docker exec in and run the tests
-  local -r WEB_CID=$(docker ps --filter status=running --format '{{.Names}}' | grep "^test_web$")
+  local -r WEB_CID="$(service_container web)"
   local -r SRC=${WEB_CID}:/tmp/cyber-dojo/coverage
   local -r DST=$(repo_root)/coverage
 

--- a/bin/show_events.sh
+++ b/bin/show_events.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 set -Eeu
 
+readonly BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${BIN_DIR}/lib.sh"
+
 ID="${1}"      # eg 3Ef6a2
 P1="${ID:0:2}" # eg 3E
 P2="${ID:2:2}" # eg f6
 P3="${ID:4:2}" # eg a2
 
-docker exec test_web_saver bash -c "jq . /cyber-dojo/katas/${P1}/${P2}/${P3}/events.json"
+docker exec "$(service_container saver)" bash -c "jq . /cyber-dojo/katas/${P1}/${P2}/${P3}/events.json"

--- a/bin/show_manifest.sh
+++ b/bin/show_manifest.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 set -Eeu
 
+readonly BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${BIN_DIR}/lib.sh"
+
 ID="${1}"      # eg 3Ef6a2
 P1="${ID:0:2}" # eg 3E
 P2="${ID:2:2}" # eg f6
 P3="${ID:4:2}" # eg a2
 
-docker exec test_web_saver bash -c "jq . /cyber-dojo/katas/${P1}/${P2}/${P3}/manifest.json"
+docker exec "$(service_container saver)" bash -c "jq . /cyber-dojo/katas/${P1}/${P2}/${P3}/manifest.json"

--- a/docker-compose-depends.yml
+++ b/docker-compose-depends.yml
@@ -2,7 +2,6 @@
 networks:
   cyber-dojo:
     driver: bridge
-    name: cyber-dojo
 
 services:
 

--- a/docker-compose-nginx.yml
+++ b/docker-compose-nginx.yml
@@ -2,18 +2,16 @@
 networks:
   cyber-dojo:
     driver: bridge
-    name: cyber-dojo
 
 services:
 
   nginx:
     image: ${CYBER_DOJO_NGINX_IMAGE}:${CYBER_DOJO_NGINX_TAG}
-    container_name: test_web_nginx
     depends_on:
       - web
     user: root
     init: true
-    ports: [ "${CYBER_DOJO_NGINX_PORT}:80" ]
+    ports: [ "${CYBER_DOJO_NGINX_HOST_PORT}:80" ]
     restart: "no"
 
   # for demo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@
 networks:
   cyber-dojo:
     driver: bridge
-    name: cyber-dojo
 
 services:
 
@@ -27,14 +26,12 @@ services:
   web:
     image: ${CYBER_DOJO_WEB_IMAGE}:${CYBER_DOJO_WEB_TAG}
     platform: linux/amd64
-    ports: [ "${CYBER_DOJO_WEB_PORT}:${CYBER_DOJO_WEB_PORT}" ]
     build:
       context: .
       args:
         - COMMIT_SHA
         - BASE_IMAGE
     user: nobody
-    container_name: test_web
     env_file: [ web.env ]
     restart: no
     volumes:
@@ -47,7 +44,6 @@ services:
     image: ${CYBER_DOJO_CREATOR_IMAGE}:${CYBER_DOJO_CREATOR_TAG}
     platform: linux/amd64
     user: nobody
-    container_name: test_web_creator
     env_file: [ .env ]
     read_only: true
     tmpfs: /tmp
@@ -57,7 +53,6 @@ services:
     image: ${CYBER_DOJO_CUSTOM_START_POINTS_IMAGE}:${CYBER_DOJO_CUSTOM_START_POINTS_TAG}
     platform: linux/amd64
     user: nobody
-    container_name: test_web_custom_start_points
     env_file: [ .env ]
     read_only: true
     tmpfs: /tmp
@@ -67,7 +62,6 @@ services:
     image: ${CYBER_DOJO_EXERCISES_START_POINTS_IMAGE}:${CYBER_DOJO_EXERCISES_START_POINTS_TAG}
     platform: linux/amd64
     user: nobody
-    container_name: test_web_exercises_start_points
     env_file: [ .env ]
     read_only: true
     tmpfs: /tmp
@@ -77,7 +71,6 @@ services:
     image: ${CYBER_DOJO_LANGUAGES_START_POINTS_IMAGE}:${CYBER_DOJO_LANGUAGES_START_POINTS_TAG}
     platform: linux/amd64
     user: nobody
-    container_name: test_web_languages_start_points
     env_file: [ .env ]
     read_only: true
     tmpfs: /tmp
@@ -87,7 +80,6 @@ services:
     image: ${CYBER_DOJO_RUNNER_IMAGE}:${CYBER_DOJO_RUNNER_TAG}
     platform: linux/amd64
     user: root
-    container_name: test_web_runner
     env_file: [ .env ]
     read_only: true
     tmpfs: /tmp
@@ -97,9 +89,7 @@ services:
   saver:
     image: ${CYBER_DOJO_SAVER_IMAGE}:${CYBER_DOJO_SAVER_TAG}
     platform: linux/amd64
-    ports: [ "${CYBER_DOJO_SAVER_PORT}:${CYBER_DOJO_SAVER_PORT}" ]
     user: root
-    container_name: test_web_saver
     env_file: [ .env ]
     read_only: true
     restart: no
@@ -109,7 +99,6 @@ services:
     image: ${CYBER_DOJO_DIFFER_IMAGE}:${CYBER_DOJO_DIFFER_TAG}
     platform: linux/amd64
     user: nobody
-    container_name: test_web_differ
     env_file: [ .env ]
     read_only: true
     tmpfs: /tmp
@@ -119,7 +108,6 @@ services:
     image: ${CYBER_DOJO_DASHBOARD_IMAGE}:${CYBER_DOJO_DASHBOARD_TAG}
     platform: linux/amd64
     user: nobody
-    container_name: test_web_dashboard
     env_file: [ .env ]
     read_only: true
     restart: no


### PR DESCRIPTION
  Each repo's demo brought up the same stack on fixed canonical host
  ports (saver 4537, web 3000, ...), a hardcoded `cyber-dojo` network
  name, and fixed container names. So a demo in one repo (e.g. web)
  could not run while a demo in another (e.g. differ) was up: they
  fought over the same host ports and shared network. The workaround
  was to let the new demo nuke everything with `docker rm -f`.

  Make each demo its own docker-compose project instead:
  - Drop the hardcoded network name and per-service container_name so Compose namespaces them by project (COMPOSE_PROJECT_NAME, default web). Override it to run a second web demo alongside the first.
  - Stop publishing web and saver to the host; only nginx needs a host port (CYBER_DOJO_NGINX_HOST_PORT). Backend services reach each other over the project's private network, so nothing else collides. asset_builder is left alone (not part of the demo; build_assets.sh needs its publish).
  - Replace demo.sh's global `docker rm -f` with a project-scoped `compose down`, so bringing up one demo no longer kills the others.

  Container references in the helper scripts no longer assume fixed
  names; they resolve by compose project+service label via a shared
  service_container() in lib.sh. This also fixes copy_in_saver_test_data
  which previously grepped the `web_saver` substring of the old name.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>