### PR TITLE
Add immutable directive to asset Cache-Control headers

### DIFF
--- a/source/app/app.rb
+++ b/source/app/app.rb
@@ -75,13 +75,13 @@ class App < Sinatra::Base
   # Assets
 
   get CSS_PATH do
-    cache_control :public, max_age: 31536000
+    cache_control :public, max_age: 31536000, immutable: true
     content_type 'text/css'
     send_file "#{ASSETS_DIR}/app.css"
   end
 
   get JS_PATH do
-    cache_control :public, max_age: 31536000
+    cache_control :public, max_age: 31536000, immutable: true
     content_type 'text/javascript'
     send_file "#{ASSETS_DIR}/app.js"
   end

--- a/source/test/app_controllers/assets_test.rb
+++ b/source/test/app_controllers/assets_test.rb
@@ -3,21 +3,33 @@ require_relative 'app_controller_test_base'
 class AssetsTest < AppControllerTestBase
 
   test 'EB5001', %w(
-  | hashed CSS path returns 200 with text/css and one-year cache-control
+  | hashed CSS path returns 200 with text/css and one-year immutable cache-control
   ) do
     get App::CSS_PATH
     assert_equal 200, last_response.status
     assert_includes last_response.content_type, 'text/css'
-    assert_includes last_response.headers['Cache-Control'], 'max-age=31536000'
+    cache_control = last_response.headers['Cache-Control']
+    assert_includes cache_control, 'max-age=31536000', cache_control
+    assert_includes cache_control, 'immutable', cache_control
   end
 
   test 'EB5002', %w(
-  | hashed JS path returns 200 with text/javascript and one-year cache-control
+  | hashed JS path returns 200 with text/javascript and one-year immutable cache-control
   ) do
     get App::JS_PATH
     assert_equal 200, last_response.status
     assert_includes last_response.content_type, 'text/javascript'
-    assert_includes last_response.headers['Cache-Control'], 'max-age=31536000'
+    cache_control = last_response.headers['Cache-Control']
+    assert_includes cache_control, 'max-age=31536000', cache_control
+    assert_includes cache_control, 'immutable', cache_control
+  end
+
+  test 'EB5003', %w(
+  | each asset URL path embeds a short hash of its content, so any change
+  | to the content yields a new URL that safely busts the immutable cache
+  ) do
+    assert_match(%r{\A/assets/app-[0-9a-f]{8}\.css\z}, App::CSS_PATH, App::CSS_PATH)
+    assert_match(%r{\A/assets/app-[0-9a-f]{8}\.js\z}, App::JS_PATH, App::JS_PATH)
   end
 
 end


### PR DESCRIPTION
  Asset URLs are already fingerprinted with an 8-char content hash, so a
  given URL never returns different bytes. Marking the response immutable
  tells browsers they need never revalidate it for the cache lifetime,
  including on an explicit reload where they would otherwise fire a
  conditional request. This avoids needless revalidation round-trips
  through nginx's rate-limited zone and brings web into line with the
  more thorough setup already in ../creator.

  Extend the asset tests to assert the immutable directive (not just
  max-age) and add EB5003 verifying the fingerprinted URL shape, which
  is what makes immutable safe.