### PR TITLE
Pass group_id to cluster dashboard from [dashboard] button

### DIFF
--- a/source/app/views/shared/_dashboard.erb
+++ b/source/app/views/shared/_dashboard.erb
@@ -15,9 +15,11 @@ $(() => {
   else {
 	  $dashboardButton.click(() => {
 	      // A kata whose group belongs to a cluster carries the cluster_id;
-	      // open the dashboard on the cluster so it shows one tab per group.
-	      const id = clusterId === undefined ? groupId : clusterId;
-	      const url = `/dashboard/show/${id}`;
+	      // open the dashboard on the cluster so it shows one tab per group,
+	      // passing group_id so it opens focused on this kata's group.
+	      const url = clusterId === undefined
+	          ? `/dashboard/show/${groupId}`
+	          : `/dashboard/show/${clusterId}?group_id=${groupId}`;
 	      window.open(url);
       });
       cd.createTip($dashboardButton, 'open dashboard page');


### PR DESCRIPTION
  The dashboard's show/<CLUSTER_ID> now accepts a ?group_id=<GID> query
  that focuses the cluster view on a single group. When a kata's group
  belongs to a cluster, the [dashboard] button opens the cluster view, so
  append the kata's group_id to land on that group's tab rather than the
  cluster's default. The group-only case (no cluster) is unchanged.