### PR TITLE
Fix false "mobbing?" dialog for a solo user on an unshared kata

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-# This file is generated in sh/lib.sh echo_env_vars()
+# This file is generated in bin/lib.sh echo_env_vars()
 CYBER_DOJO_CUSTOM_START_POINTS_PORT=4526
 CYBER_DOJO_EXERCISES_START_POINTS_PORT=4525
 CYBER_DOJO_LANGUAGES_START_POINTS_PORT=4524

--- a/bin/echo_env_vars.sh
+++ b/bin/echo_env_vars.sh
@@ -10,7 +10,7 @@ echo_env_vars()
   fi
 
   {
-    echo "# This file is generated in sh/lib.sh echo_env_vars()"
+    echo "# This file is generated in bin/lib.sh echo_env_vars()"
     run_versioner | grep PORT
     echo CYBER_DOJO_PROMETHEUS=true
   } > "$(repo_root)/.env"

--- a/source/app/app.rb
+++ b/source/app/app.rb
@@ -297,6 +297,19 @@ class App < Sinatra::Base
   end
 
   # - - - - - - - - - - - - - - - -
+  # The next event index the browser should hold. Lets a browser that lost
+  # the response to an inter-test file event (eg its fetch aborted while the
+  # saver still committed the event) resync its index to the committed head,
+  # instead of sending a stale index the saver would reject as an out-of-order
+  # event and the browser would show as a false mobbing dialog.
+
+  get '/kata/next_index/:id' do
+    content_type :json
+    events = saver.kata_events(params[:id])
+    { next_index: events.last['index'] + 1 }.to_json
+  end
+
+  # - - - - - - - - - - - - - - - -
   # Errors
 
   get '*' do

--- a/source/app/views/kata/_file_inter_test_events.erb
+++ b/source/app/views/kata/_file_inter_test_events.erb
@@ -53,17 +53,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
   cd.saveAnyFileChangesITE = (callback) => {
     cd.saveCodeFromSyntaxHighlightEditors();
-    _interTestEventInProgress = true;
     const args = { id: kata.id, index: kata.index };
-    syncPostWithCallbackITE('/kata/file_edit', args, () => {
-      _interTestEventInProgress = false;
-      callback();
-    });
+    syncPostWithCallbackITE('/kata/file_edit', args, callback);
   };
 
   const syncPostWithCallbackITE = (url, args, callback) => {
+    // Hold the in-progress flag for the whole request so cd.waitForITE()
+    // (guarding [test] and the file create/delete/rename buttons) waits for
+    // this event to resolve before firing the next save at kata.index.
+    _interTestEventInProgress = true;
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 2000);
+    const timer = setTimeout(() => controller.abort(), 30000);
     const body = new URLSearchParams(args);
     body.set('data', new URLSearchParams(new FormData(document.querySelector('form'))).toString());
     fetch(url, {
@@ -78,9 +78,22 @@ document.addEventListener('DOMContentLoaded', () => {
     })
     .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
     .then(newIndex => kata.setIndex(newIndex))
-    .catch(() => console.warn('inter-test file-edit was rate-limited'))
-    .finally(() => { clearTimeout(timer); callback(); });
+    // If the response is lost (aborted, network drop) the saver may still
+    // have committed the event, leaving kata.index stale. Sending that stale
+    // index on the next [test] is what the saver reports as an out-of-order
+    // event and the browser shows as a false 'mobbing?' dialog. Resync
+    // kata.index to the committed head so the next save is in step.
+    .catch(() => resyncIndex())
+    .finally(() => { clearTimeout(timer); _interTestEventInProgress = false; callback(); });
   };
+
+  const resyncIndex = () =>
+    fetch(`/kata/next_index/${kata.id}`, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+    // r.ok guards a web instance without this route (eg an older instance
+    // still up mid-deploy), which 404s: reject rather than parse its HTML.
+    .then(r => r.ok ? r.json() : Promise.reject())
+    .then(data => kata.setIndex(data.next_index))
+    .catch(() => {}); // leave kata.index as-is; a browser refresh also resyncs
 
 });
 </script>

--- a/source/test/app_controllers/kata_next_index_test.rb
+++ b/source/test/app_controllers/kata_next_index_test.rb
@@ -1,0 +1,30 @@
+require_relative 'app_controller_test_base'
+
+class KataNextIndexTest < AppControllerTestBase
+
+  test 'q7F3a1', %w(
+  | GET /kata/next_index/:id returns the next index the browser should hold:
+  | on a freshly created kata (only the index-0 created event) that is 1.
+  ) do
+    in_kata do
+      get '/kata/next_index/' + @id
+      assert last_response.ok?, last_response.body
+      assert_equal 1, json['next_index']
+    end
+  end
+
+  test 'q7F3a2', %w(
+  | GET /kata/next_index/:id returns last_committed_index + 1 after events
+  | have been added, so a browser can resync to the committed head.
+  ) do
+    in_kata do
+      post_run_tests               # adds a ran_tests event
+      post_run_tests               # adds another
+      last_index = saver.kata_events(@id).last['index']
+      get '/kata/next_index/' + @id
+      assert last_response.ok?, last_response.body
+      assert_equal last_index + 1, json['next_index']
+    end
+  end
+
+end

--- a/source/test/app_controllers/mobbing_resync_after_lost_event_test.rb
+++ b/source/test/app_controllers/mobbing_resync_after_lost_event_test.rb
@@ -1,0 +1,44 @@
+require_relative 'app_controller_test_base'
+
+class MobbingResyncAfterLostEventTest < AppControllerTestBase
+
+  test 'kT9mB2', %w(
+  | A solo user on an unshared kata can lose the response to an inter-test
+  | file event: the saver commits it and advances the head, but the browser's
+  | 2s abort fires so it never applies the returned index. The browser must be
+  | able to resync its index from GET /kata/next_index/:id and then run its
+  | tests cleanly - it must NOT get a false out-of-sync (mobbing) dialog.
+  ) do
+    in_kata do |kata|
+      # Browser is synced: the only event is the index-0 created event,
+      # so the next index to write is 1.
+      stale_index = @index
+      assert_equal 1, stale_index
+
+      # The browser fires an inter-test file_create. The saver commits it
+      # (advancing the head) but the browser loses the response (2s abort),
+      # so its own index counter stays at stale_index.
+      post_json '/kata/file_create', {
+        id:       @id,
+        index:    stale_index,
+        data:     { file_content: @files },
+        filename: 'scratch.txt'
+      }
+      assert last_response.ok?, last_response.body
+      committed_next = saver.kata_events(@id).last['index'] + 1
+      assert_operator committed_next, :>, stale_index,
+        'the lost inter-test event should have advanced the head'
+
+      # Option A resync: rather than staying stale, the browser re-reads its
+      # authoritative next index from the server.
+      get '/kata/next_index/' + @id
+      assert last_response.ok?, last_response.body
+      assert_equal committed_next, json['next_index']
+
+      # With the resynced index the next run-tests saves cleanly: no mobbing.
+      post_run_tests(index: json['next_index'])
+      refute json['out_of_sync'], json
+    end
+  end
+
+end


### PR DESCRIPTION
  The "mobbing?" dialog is meant to fire only when two or more laptops
  share a kata-id and their [test] submissions interfere. But a single
  user working alone could trigger it too.

  Cause: an inter-test file event (create/delete/rename/edit) posts at the
  browser's current index and advances it only from the response. Its fetch
  aborted after 2s, so a slow-but-successful save committed on the server
  while the browser never applied the returned index. The browser's index
  was now behind the committed head, and the next [test] sent that stale
  index, which the saver rejects as an "Out of order event" and the browser
  renders as "mobbing?". nginx rate-limiting was ruled out: a 429 is
  rejected before it reaches the saver, so it never commits and never
  desyncs the index.

  Fix (web only; saver and the index contract are unchanged):
  - Add GET /kata/next_index/:id returning last_committed_index + 1, the authoritative index a browser resyncs to.
  - On a lost/failed inter-test response, resync the browser index from that endpoint instead of silently leaving it stale (and drop the misleading "rate-limited" log). Degrades safely if the endpoint is absent (eg an older web instance mid-deploy): it 404s, resync no-ops, index unchanged.
  - Hold the in-progress flag for every inter-test event, not just file_edit, so a following [test] waits behind an in-flight file op.
  - Raise the inter-test abort 2s -> 30s (matching [test]); the 2s was not guarding any rate limiter and was the main trigger for abandoning a commit that actually landed.

  The additive route and graceful client fallback keep a mid-session deploy
  safe: every old/new browser-vs-server combination is either fixed or the
  prior behavior, never worse.

  Adds a dedicated endpoint test and a lost-event recovery test.