### PR TITLE
End the false "mobbing?" dialog (web side)

### DIFF
--- a/bin/containers_up.sh
+++ b/bin/containers_up.sh
@@ -12,6 +12,6 @@ containers_up()
     --detach \
     --no-build \
     --wait \
-    --wait-timeout=10 \
-    web runner saver
+    --wait-timeout=60 \
+    web runner saver selenium
 }

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -Eeu
 
+# Silence the docker CLI "What's next:" hint banner (eg the docker scout
+# suggestion printed after pull/compose) for the whole test run.
+export DOCKER_CLI_HINTS=false
+
 repo_root() { git rev-parse --show-toplevel; }
 export BIN_DIR="$(repo_root)/bin"
 

--- a/bin/run_tests_in_container.sh
+++ b/bin/run_tests_in_container.sh
@@ -40,7 +40,16 @@ run_tests_in_container()
   # Drop set -e because we want to get coverage stats out
   set +e
   docker exec --user nobody "${WEB_CID}" sh -c "cd /web/source/test && ./run.sh ${*:-}"
-  readonly STATUS=$?
+  local -r UNIT_STATUS=$?
+
+  # Browser (Capybara + Selenium) tests run as a separate script: they exercise
+  # the served app end-to-end, so they are kept out of run.sh's per-module
+  # coverage loop. Only on a full run (no single module requested).
+  local BROWSER_STATUS=0
+  if [ $# -eq 0 ]; then
+    docker exec --user nobody "${WEB_CID}" sh -c "cd /web/source/test && ./run_browser.sh"
+    BROWSER_STATUS=$?
+  fi
   set -e
 
   mkdir -p "${DST}"
@@ -51,5 +60,8 @@ run_tests_in_container()
   echo "${DST}/app_services/index.html"
   echo "${DST}/app_controllers/index.html"
 
-  return ${STATUS}
+  if [ ${UNIT_STATUS} -ne 0 ]; then
+    return ${UNIT_STATUS}
+  fi
+  return ${BROWSER_STATUS}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,16 @@ services:
     image: selenium/standalone-firefox
     platform: linux/amd64
     restart: no
+    # So containers_up's --wait blocks until the grid is actually accepting
+    # sessions on 4444, not merely until the container is running - otherwise
+    # the first browser test can hit connection-refused. check-grid.sh ships in
+    # the selenium image.
+    healthcheck:
+      test: [ "CMD", "/opt/bin/check-grid.sh", "--host", "0.0.0.0", "--port", "4444" ]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+      start_period: 10s
 
   creator:
     image: ${CYBER_DOJO_CREATOR_IMAGE}:${CYBER_DOJO_CREATOR_TAG}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,16 @@ services:
       - ./source/test:/web/source/test:ro
       - ./source/lib:/web/source/lib:ro
 
+  # The browser (Capybara) tests in source/test/app_browser drive Firefox here
+  # and load the web app at http://web:3000 over the compose network, so they
+  # exercise the rendered page and its JavaScript end to end (the in-process Rack
+  # tests never run browser JS). amd64 image (emulated on arm hosts), matching
+  # ../creator's selenium service.
+  selenium:
+    image: selenium/standalone-firefox
+    platform: linux/amd64
+    restart: no
+
   creator:
     image: ${CYBER_DOJO_CREATOR_IMAGE}:${CYBER_DOJO_CREATOR_TAG}
     platform: linux/amd64

--- a/docs/mobbing-concurrent-write-fix.md
+++ b/docs/mobbing-concurrent-write-fix.md
@@ -1,0 +1,181 @@
+# Mobbing false-positive: the concurrent-write cause and the agreed fix
+
+Status: implemented and tested, uncommitted, not deployed. WEB: Phase 3, the cause-2
+fix, `laptop_id` forwarding, and the `runTests` re-entry guard (the write-during-test
+resolution - step 2 below). SAVER: Phase 1+2 and the directional CAS-loss retry in
+`commit_event`. All three rescue directions are covered: DccG02 (different-laptop
+reject), DccG03 (same-laptop test retry), DccG04 (same-laptop file-edit drop). Only the
+retry-exhaustion sub-branch is uncovered (cannot be forced deterministically).
+
+Related docs (all in web `docs/`):
+- `mobbing-server-owned-index-design.md` - Option C (server-owned index +
+  per-laptop id + self-lag detection). Its concurrency bullet now documents the
+  CAS-loss gap described here.
+- `mobbing-web-index-desync-causes.md` - the three web-side causes (1 waitForITE 2s
+  bail, 2 run_tests rescue advances index, 3 lost [test] response).
+- `mobbing-waitforite-2s-gate-finding.md`, `mobbing-laptop-id-design.md`.
+
+Related memories:
+- `saver-cas-loss-no-retry` - the CAS-loss rescue rejects any concurrent loser with
+  no laptop_id check and no retry (the design doc's claimed retry does NOT exist).
+- `saver-write-methods-index-advance`, `saver-service-laptop-id-required-arg`.
+
+## The exact trigger
+
+The "mobbing?" dialog fires ONLY when a `POST /kata/run_tests` makes the saver raise
+`"Out of order event"` (that is the sole source of `out_of_sync: true`, mapped in
+`app.rb` and rendered by `_run_tests.erb`'s `showAvatarsOutOfSync`). So every false
+dialog is a solo `[test]` reaching the saver with a rejectable index. Under Option C
+there are exactly two ways to be rejected: index AHEAD of `head + 1`, or index BEHIND
+with a foreign/absent `laptop_id` in the `index .. head` range.
+
+## What is already closed or decided
+
+- AHEAD (`index > head + 1`): closed by Phase 3 + the cause-2 fix. Every browser
+  index update is now `setIndex(committed_index + 1)` (page load, run_tests,
+  revert, checkout, inter-test); `incrementIndex` is gone; the cause-2 fix stops
+  advancing the index when a save did not commit. A committed index is always
+  `<= head`, so `index <= head + 1` always. Nothing can push it ahead. (Holds only
+  once the WEB Phase 3 + cause-2 changes are deployed; old web still has
+  `incrementIndex` and the cause-2 bug.)
+- BEHIND, writes SEQUENTIAL: fixed by self-lag in the saver's `commit_on_main`
+  block (Phase 2). Requires web forwarding `laptop_id` AND the saver deployed.
+- Cause 2 (run_tests rescue fabricated `index + 1` on a non-committing save):
+  FIXED in the web working tree - `app.rb` now returns `saved:`, and
+  `refreshFromTest` only advances the index when `saved`. Locked by
+  `run_tests_save_error_test.rb`.
+- Cause 3 (lost `[test]` response): closed by self-lag; covered by
+  `mobbing_self_lag_after_lost_event_test.rb` (its second write is a `[test]` at a
+  stale index that self-lag-accepts).
+
+## The remaining live cause: concurrent same-laptop CAS loss
+
+The saver's `laptop_id` self-lag verdict runs ONLY in the sequential path (inside
+`git.commit_on_main`). The CONCURRENT path (two writes to one kata racing the git
+`update-ref` compare-and-swap) is resolved by `commit_event`'s method-level
+`rescue`, which re-reads the tip and, if it advanced to `>= index`, raises
+`"Out of order event"` - with NO `laptop_id` check and NO retry.
+
+So two CONCURRENT writes from the SAME browser both build on the same base, both pass
+the sequential check (both see an empty range at `head + 1`), then race the CAS; the
+loser hits the `rescue` and is rejected. If the loser is the `[test]`, that is the
+false dialog.
+
+Reachability (verified): web puma has no `threads` directive (default multi-threaded,
+so it forwards the two same-browser fetches concurrently); the saver runs
+`workers Etc.nprocessors` (10 worker processes observed). The saver's own
+`config/puma.rb` comment documents this exact behaviour: two concurrent writes to one
+kata, one wins the CAS, "the other fails and is detected as an 'Out of order event'
+error, which the web layer treats as an out-of-sync condition and shows a dialog."
+
+Main generator: `waitForITE`'s 2s bail (cause 1) fires `[test]` while an inter-test
+event is still in flight, so the two race. In a busy group session (loaded saver,
+slower ITEs, more 2s bails, more concurrency) this is very plausibly the instructor's
+dominant ongoing trigger. It is not limited to `waitForITE`: any two concurrent
+same-laptop writes to one kata hit it.
+
+## Alternatives considered and rejected
+
+- Blind saver retry (retry whichever writer loses the CAS): REJECTED. If the `[test]`
+  wins and the older ITE loses, retrying the ITE appends it AFTER the test, storing
+  `(ITE, test)` in REVERSE chronological order - and the test event already contains
+  the ITE's file change, so the ITE is re-recorded after the test that superseded it.
+  Corrupts the log's meaning.
+- Disable / wait (block `[test]` while an ITE is in flight): REJECTED. Re-enabling
+  only on the ITE's completion means a slow or hung saver blocks test-running (and
+  file edits) for up to the 30s ITE abort. That violates the invariant "you must be
+  able to run tests and edit files even if the saver is completely broken." (A
+  down/refused saver fails fast; a hung or slow-under-load saver does not - and
+  slow-under-load is exactly the instructor's condition.) The old 2s bail existed to
+  avoid this block, at the cost of the race.
+- Web `[test]` re-submit (re-POST run_tests on a self-lag "Out of order"): REJECTED as
+  primary. It re-runs the RUNNER (Docker compile+test) on a raced `[test]`, adding
+  load precisely under the slow saver that triggers the race.
+- Drop `waitForITE` from the `[test]` button (`_test_button.erb`): REJECTED. It looks
+  redundant once the retry handles the race, but `waitForITE` is load-bearing for
+  STRUCTURAL ops. create/delete/rename send their ITE POST first (filename as a POST
+  arg) and mutate the browser editor file-set only in the ITE's `.finally` callback,
+  i.e. AFTER the POST (coupled to the saver: `file_create` expects the file NOT yet in
+  `files`). So the browser file-SET lags the ITE. If `[test]` fired during an in-flight
+  create/rename, its form would miss the structural change and could undo it.
+  `waitForITE` waits for that callback to apply before the next save. (file_edit is the
+  opposite - its content is copied into the form before the POST - so only the
+  structural ops need the guard.) We keep `waitForITE`; the retry handles the residual
+  2s-bail race.
+
+## The chosen fix: type-discriminated directional saver retry + web write-during-test gate
+
+Key insight: the reverse-order problem only occurs when the OLDER write is retried.
+Retrying the NEWER write (the `[test]`, appended after an earlier ITE) yields CORRECT
+order. And the saver can tell them apart WITHOUT a new API argument, by the write TYPE
+already in `summary` (a rag colour for a test vs `file_edit`/`file_create`/... for an
+ITE). The existing `index` cannot discriminate concurrent losers - two in-flight
+writes carry the same `index` (neither has returned) - so type, not index, is the
+discriminator. Also note: a saver-internal retry re-attempts only the git commit
+(rebuild on the new head + re-CAS), NOT the runner, so there is NO double-run.
+
+SAVER side (`source/server/model/kata_v2.rb`, `commit_event` CAS-loss `rescue`):
+- Loser is a `[test]` (rag `summary`) and the racing events are the SAME `laptop_id`:
+  retry - rebuild on the new head and re-CAS, appending at `head + 1` (correct order).
+  Bounded retries; if exhausted, raise (rare).
+- Loser is a `[test]` and a DIFFERENT `laptop_id` is in the range: raise "Out of order"
+  (genuine mobbing - the real dialog).
+- Loser is a file-event: raise as today; its client `.catch` drops it silently
+  (file-events never show the dialog, and its file content is already in the
+  concurrent winner). No retry.
+
+WEB side (browser JS in the `.erb` views): the type discriminator is only correct if a
+file-event is never the NEWER write in a race with a test, i.e. no file-event may START
+during a `[test]` run. This turned out to already hold, with one small exception now
+closed:
+- File-events cannot fire during a run. Every file-event trigger is a MOUSE action
+  (file create/delete/rename buttons, mouse file-select in the list, predict
+  checkboxes), and `#wait-overlay` (full-page, `pointer-events` on) blocks all clicks
+  during a run. The keyboard file-nav shortcuts (Alt-J/K next/prev, Alt-O toggle)
+  deliberately fire NO inter-test-event - by design, to avoid rate-limiting from rapid
+  cycling - so keyboard cannot fire a file-event either. So no extra file-event gate is
+  needed.
+- The one residual was test-vs-test, not a file-event: Alt-T/R/A/G run a test/predict
+  via keyboard and bypass the overlay, so pressing one mid-run could start a SECOND
+  concurrent test. Both retry and commit (no dialog), but a lost older test could land
+  after the newer one (cosmetic reverse order) plus a wasted runner run. Closed by a
+  re-entry guard in `cd.kata.runTests` (`_run_tests.erb`): every test-trigger (button,
+  predict buttons, all Alt-keys) funnels through it, so one `runTestsInProgress` flag
+  covers them all. It gates only the RUN, not a save, so it does not touch the
+  resilience constraint (a hung save never blocks editing).
+- We deliberately do NOT gate `[test]` while an ITE is in flight (that is the
+  resilience-breaking disable/wait we rejected). `[test]` fires freely; the saver
+  retry handles a loss.
+
+## Remaining work, by repo
+
+WEB (`cyber-dojo/web`) - browser JS/CSS: DONE (uncommitted in the web tree).
+- Phase 3, the cause-2 fix, and the `laptop_id` forwarding.
+- The write-during-test resolution (step 2): confirmed `#wait-overlay` blocks all
+  mouse clicks during a run and keyboard file-nav fires no ITE, so no file-event gate
+  was needed; added the `cd.kata.runTests` re-entry guard for the test-vs-test edge.
+
+SAVER (`cyber-dojo/saver`) - `source/server/model/kata_v2.rb`:
+2. DONE (uncommitted): directional retry in `commit_event`'s CAS-loss `rescue` plus
+   `COMMIT_EVENT_MAX_RETRIES`. DccG02 (different-laptop reject) and DccG03 (same-laptop
+   test retry) pass.
+3. DONE (uncommitted): DccG04 covers the directional DROP branch - N concurrent
+   same-`laptop_id` file-edits making the same edit at index 1; exactly one commits, the
+   CAS-loss losers are dropped as "Out of order event", the log stays contiguous. A
+   single mixed file-edit + `[test]` test was rejected as inherently flaky: `ran_tests`
+   runs an internal `file_edit` first (`kata_v2.rb:263`), which can itself lose the CAS
+   and drop, losing the test event depending on race timing. So the three directions are
+   covered separately (DccG02/DccG03/DccG04) rather than in one test. Only
+   `attempts >= COMMIT_EVENT_MAX_RETRIES` (retry exhaustion) stays uncovered - it cannot
+   be forced deterministically from a client test.
+
+## Deploy dependencies
+
+The false positive is only fully crushed when ALL of these are deployed:
+- SAVER: Phase 1 (accept + store `laptop_id`) + Phase 2 (sequential self-lag) + the
+  new concurrent CAS-loss retry.
+- WEB: Phase 1 (mint + forward `laptop_id`) + cause-2 fix + Phase 3 + the
+  write-during-test gate.
+
+Saver-alone fixes nothing: without web forwarding `laptop_id`, the saver falls back to
+the legacy index check and every stale solo `[test]` still false-dialogs.

--- a/docs/mobbing-laptop-id-design.md
+++ b/docs/mobbing-laptop-id-design.md
@@ -1,0 +1,175 @@
+# Mobbing false-positive: per-laptop-id design (Option B)
+
+Status: design only, not implemented. Option A (below) is implemented and shipped.
+
+## The problem
+
+The "mobbing?" dialog is meant to fire only when two or more laptops share a
+kata-id and their [test] submissions interfere. A single user working alone on
+an unshared kata could trigger it too.
+
+Mechanism (verified on a running stack):
+
+- The browser holds its own next-event `index` (a hidden field, see
+  `_index.erb`) and advances it only from a successful response.
+- An inter-test file event (create/delete/rename/edit) posts at that index and,
+  when its response is lost (fetch abort, network drop) while the saver still
+  committed the event, the browser never applies the returned index. The
+  browser's `index` is now behind the committed head.
+- The next [test] sends that stale index. The saver's check
+  (`kata_v2.rb`, `index == last['index'] + 1`) fails and raises
+  `"Out of order event"`, which `app.rb` turns into `out_of_sync: true` and the
+  browser renders as "mobbing?".
+
+Ruled out: nginx rate-limiting. A 429 is rejected at nginx before it reaches the
+saver, so it never commits and never desyncs the index (verified: a rapid burst
+of file_create posts returned 403/429 and the committed head was unchanged).
+
+## Governing constraint
+
+The client-owned index does double duty: correctness bookkeeping AND the mobbing
+signal. At the saver, a genuine collision and a solo lost-response are identical:
+both look like "your index is behind the head". Any fix must either stop the solo
+case from desyncing the counter, or give the saver a way to tell the two apart.
+
+## Option A (implemented): client resync on a lost inter-test response
+
+Web-only, saver untouched.
+
+- New `GET /kata/next_index/:id` returns `last_committed_index + 1`, the
+  authoritative index a browser resyncs to. Proving tests: `q7F3a1`, `q7F3a2`
+  in `test/app_controllers/kata_next_index_test.rb`.
+- On a lost/failed inter-test response the client resyncs its index from that
+  endpoint instead of leaving it stale (`_file_inter_test_events.erb`,
+  `resyncIndex`). Recovery proving test: `kT9mB2` in
+  `test/app_controllers/mobbing_resync_after_lost_event_test.rb`.
+- The in-progress flag is held for every inter-test event (not just file_edit),
+  so a following [test] waits behind an in-flight file op.
+- The inter-test abort was raised from 2s to 30s (it was not guarding a rate
+  limiter and was the main trigger for abandoning a commit that actually landed).
+
+What Option A does NOT close: any other path where the browser's index legitimately
+lags the head, most notably a slow [test] whose response is lost and is then
+re-run by the user at the same (now stale) index. Option A only covers the
+inter-test path.
+
+## Option B: per-laptop id, discriminate self-lag from another laptop
+
+The distinguishing signal for genuine mobbing is not a token on the current
+request; it is who wrote the events sitting between the browser's index and the
+head. Tag every committed event with the writing laptop's id. When a save arrives
+with a stale index, inspect the events in `(index .. head]`:
+
+- all written by THIS laptop id -> the browser's own committed-but-unacknowledged
+  writes -> accept / resync silently, no dialog.
+- any written by a DIFFERENT laptop id -> genuinely another laptop -> raise, show
+  the dialog.
+
+This makes the dialog mean exactly "two laptops interfered". It closes the whole
+class (the inter-test case AND the slow-[test]-retry case), because both are "my
+own session got ahead of my browser's counter".
+
+### The invariant that keeps it safe
+
+The id logic may only RELAX a stale-index verdict, never trigger a new one. The
+non-stale path (`index == head + 1`) is untouched. Consequences:
+
+- A normally-progressing user (always sends `head + 1`) never hits the examined
+  path, so the id is never even looked at.
+- The saver can only become more permissive than today, never less. No request
+  that succeeds today can fail after Option B lands.
+
+### Where the per-laptop id comes from
+
+Mirror the existing CSRF-token cookie pattern in `app.rb`:
+
+```ruby
+before do
+  @csrf_token = request.cookies['csrf_token']
+  unless @csrf_token
+    @csrf_token = SecureRandom.hex(32)
+    response.set_cookie('csrf_token', value: @csrf_token, path: '/')
+  end
+```
+
+Add a parallel `laptop_id` cookie the same way, then forward it to the saver on
+every write so each event is stamped with the laptop that wrote it. A cookie
+satisfies every constraint:
+
+- Stable across reloads (persists), so a refresh keeps the same id. This is what
+  stops a solo user's own mid-kata refresh from becoming a false positive.
+- Distinct per browser, so two laptops get different ids.
+- Independent random, so it is not derivable from kata-id or avatar (which are
+  shared during genuine mobbing) and can actually distinguish two laptops.
+- Sent automatically on every request, no per-fetch JS wiring.
+
+Default to a session-scoped cookie (cleared on browser close); that is enough for
+stability across reloads. A localStorage UUID sent as a header is an alternative
+if survival across browser-close is wanted, but it needs explicit JS on each save.
+
+### Handoff and browser-switch correctness
+
+A legitimate handoff goes through a re-enter plus refresh. The edit page embeds
+the events array and runs `setIndex(events.length)` (`edit.erb`), syncing the new
+browser to `head + 1`. A refreshed browser is never stale, so its id is never
+examined. Verified on the stack: after Laptop A drove a kata to head index 11,
+Laptop B's refresh synced to index 12 and its [test] saved cleanly
+(`HTTP 200, mobbing=false`), while the same [test] at the pre-refresh index 11
+raised `"Out of order event"`.
+
+Switching browser on one laptop is mechanically identical: the new browser has a
+different id but re-syncs on load, so it behaves like a rotation to another
+laptop and works. If the OLD browser is left open and used again after the new one
+committed events, it is genuinely stale against events with a different id and is
+correctly flagged: two live sessions on one kata are interfering, which is what
+the dialog is for.
+
+Invariant in one line: a session that re-syncs (refreshes) is fine regardless of
+id; the id only adjudicates a stale index, i.e. a session that got left behind.
+
+### Edge cases
+
+- Two tabs, one laptop: same cookie, same id, treated as self (no dialog). Matches
+  the feature's stated intent ("two or more laptops"). Conscious call, not an
+  accident.
+- Cookie cleared / incognito / new browser mid-kata: new id, but that path goes
+  through a page load that re-syncs the index, so it is not stale and the id is
+  never examined. Safe.
+- Legacy events (committed before Option B ships, no `laptop_id`): the saver
+  cannot prove they are "mine", so it must fail toward the dialog, which is
+  exactly today's behavior. Backward compatible and errs on the safe side (never
+  silently interleave two real laptops).
+
+### Deploy safety (the saver changes this time)
+
+An in-progress kata will not get a spurious mobbing just because Option B lands,
+given the invariant above and an additive field:
+
+- A normally-progressing (non-stale) user is never examined, so sees no change.
+- A stale index over legacy events falls back to today's behavior.
+- The `laptop_id` field is additive: an old saver instance ignores the extra key
+  on new events; a new instance defaults the missing key on old events. No
+  migration, no format break, `events.json` stays the single source of truth.
+- Rolling window with mixed old/new saver instances: a request handled by an old
+  instance runs today's check, so worst case is today's behavior.
+- Deploy order of web vs saver does not matter: a missing id always degrades to
+  today's behavior.
+
+## Assumptions
+
+- Event indices are contiguous `0..N`, so `events.length == last_index + 1`
+  (relied on by both the resync endpoint and `edit.erb`).
+- The saver is the single source of truth for a kata's committed state; the
+  browser index is a shadow that can and does lag.
+- The `laptop_id` genuinely identifies a browser/laptop, not a kata or avatar.
+
+## Tests to write when building Option B
+
+- A non-stale, normally-progressing user is never subjected to the id check
+  (commits succeed unchanged, id is stamped).
+- A stale range whose events all carry the requester's id is accepted (resync),
+  no `out_of_sync`.
+- A stale range containing a different id raises `"Out of order event"` (genuine
+  mobbing still detected). Extends the saver `DccG02` concurrent-saves test.
+- A stale range over legacy events (no id) behaves as today (dialog).
+- Handoff: a refreshed browser at `head + 1` commits cleanly regardless of id.

--- a/docs/mobbing-server-owned-index-design.md
+++ b/docs/mobbing-server-owned-index-design.md
@@ -1,0 +1,590 @@
+# Mobbing false-positive: server-owned index design (Option C)
+
+Status: Phases 1 and 2 are implemented and tested in the `web` and `saver`
+working trees (both saver suites - server and client - and the web suites green),
+but NOT yet deployed.
+- Phase 1 (laptop_id capture): 1.1 saver accepts `laptop_id`, 1.2 web mints the
+  cookie and sends it on every write, 1.3 saver stores it on each event when it is
+  well-formed.
+- Phase 2 (saver detection): `commit_event` uses `laptop_id` to accept a solo
+  lost-response (self-lag) write and reject genuine two-laptop mobbing, instead of
+  rejecting every stale index.
+The remaining work is **Phase 3** (web: let the saver drive placement and retire
+the Option A resync apparatus - the browser stops owning the index for placement
+but keeps re-setting it to the saver-returned `next_index`) and **Phase 4**
+(cleanup). See "Where to pick up next" below for exactly what is left and how to do
+it.
+
+This design supersedes Option A (the `GET /kata/next_index/:id` route plus the
+client `resyncIndex`, merged as #381 to recover a browser whose owned index fell
+behind after a lost inter-test response); Phases 3-4 remove that apparatus.
+
+Before starting: the Option A stopgap (the `next_index` route, `resyncIndex`, and
+its two tests) is committed on `main` as `51953982a` ("Fix false 'mobbing?' dialog
+for a solo user on an unshared kata", #381). The Phase 1 + Phase 2 changes are
+UNCOMMITTED in the `web` and `saver` working trees (modified `app.rb`,
+`saver_service.rb`, `model.rb`, `kata_v2.rb`, plus new/edited tests). Confirm the
+real state with `git -C web status` and `git -C saver status` before assuming
+anything below - and see "Where to pick up next" for what is done vs left.
+
+Governing constraint discovered while building this (it inverts the rollout order
+below): the saver does NOT ignore unknown fields. Its dispatch
+(`saver/source/server/app_base.rb`, `json_result`) symbolizes every JSON body key
+and splats them all as keyword arguments into the target method
+(`target.public_send(method_name, **named_args)`), and the write methods in
+`saver/source/server/model.rb` declare strict required keywords with no `**`
+catch-all (e.g. `def kata_file_create(id:, index:, files:, filename:)`). So a body
+carrying an extra `laptop_id:` raises `ArgumentError: unknown keyword: laptop_id`,
+which the saver turns into HTTP 500. Therefore the saver must be taught to ACCEPT
+`laptop_id` (an optional keyword) BEFORE web ever sends it. The order is
+saver-first, then web; it is not "either order is safe".
+
+Detection needs no new field: it reuses the `index` the browser already sends on
+every write (see "Detection"). Phase 1 therefore adds only `laptop_id`; detection
+(Phase 2) reuses the existing `index`. See the "Code map" and "How to verify locally" sections at
+the end for where the current mechanism lives and how to drive it.
+
+## Where to pick up next
+
+DONE (in the `web` and `saver` working trees, tested, undeployed):
+- saver: `model.rb` accepts optional `laptop_id`; `kata_v2.rb` `commit_event`
+  stores it when well-formed and does the detection - `if laptop_id.nil?` keeps
+  today's index check, else it places at `head + 1` and rejects an ahead-of-head
+  index or a different `laptop_id` among the events in `index .. head`, accepting a
+  same-laptop stale write (self-lag). Tests:
+  `saver/test/server/kata_mobbing_detection.rb` (Mb7D01 self-lag accept, Mb7D02
+  genuine-mobbing reject, Mb7D03 ahead reject, Mb7D04 handoff accept, Mb7D05
+  nil-path reject) and end-to-end via the client
+  `saver/test/client/kata_laptop_id_test.rb` La7C03.
+- web: `app.rb` mints the `laptop_id` cookie (before-hook, mirrors `csrf_token`)
+  and exposes `attr_reader :laptop_id`; `saver_service.rb` reads
+  `externals.laptop_id` and adds it to the 9 event-write bodies. Tests:
+  `laptop_id_cookie_test.rb`, `saver_service_forwards_laptop_id_test.rb`.
+
+KEY FRAMING: the false-positive fix is delivered by DEPLOYING the above (saver
+detection + web sending `laptop_id`), NOT by Phase 3. Once deployed, a solo
+lost-response [test] sends a stale index plus its own `laptop_id`, and the saver
+accepts it as self-lag - no dialog. Phase 2 detection is a superset of Option A's
+coverage (it also fixes the slow-[test]-retry case Option A never closed), so
+Option A becomes fully redundant. Deploy order is saver-first (with `nil`
+laptop_id it is byte-identical to today - see "Deploy safety"), then web (sending
+`laptop_id` activates detection); both are only ever more-permissive than today.
+
+THE REMAINING WORK is Phase 3 (web: let the saver drive the indexing) + Phase 4
+(cleanup) - the Option C end-state, all of it behavior-neutral once the above is
+deployed and soaked. Two parts: (i) remove the Option A resync (`resyncIndex` + the
+browser's `next_index` call); (ii) for consistency with Option C's principle that
+the browser ALWAYS adopts the saver-returned index and never computes a position
+itself, switch the last two paths that still compute locally (`[checkout]` /
+`[revert]` / auto-revert, via `incrementIndex()`) to re-set from the saver response,
+then delete `incrementIndex`. Part (ii) is behavior-neutral today - those paths are
+always +1 and the local `+1` is already correct - so it is cleanup, not a fix:
+- Today web derives its next-event index two ways: (a) it re-sets `index` from the
+  saver's response on every write - `setIndex(light.index + 1)` (`_run_tests.erb`)
+  and `.then(newIndex => setIndex(newIndex))` (`_file_inter_test_events.erb`), plus
+  the `setIndex(events.length)` page-load reset (`edit.erb`) - and (b) the Option A
+  resync (`resyncIndex` + the `GET /kata/next_index/:id` route) for a lost response.
+  Under C the saver drives placement (`head + 1`) and returns the resulting
+  `next_index` (derived from the committed head), so (a) STAYS - the browser keeps
+  re-setting `index` to that returned value and thus tracks the committed head,
+  with `index` now only a detection high-water mark, not authoritative for
+  placement - and (b) is removed (self-lag + a refresh recover a lost response
+  instead). The `setIndex` helper (`_index.erb`) stays; `incrementIndex` is removed
+  once `revert()` and `cd.revertOrCheckout` switch to `setIndex` (see the Phase 3
+  bullet below).
+- Phase 3 (web): rely on the saver's placement (`head + 1`) and its returned
+  `next_index`. KEEP the response-driven re-set (`setIndex(light.index + 1)` in
+  `_run_tests.erb`, `.then(newIndex => setIndex(newIndex))` in
+  `_file_inter_test_events.erb`): the saver decides placement and returns the
+  `next_index` derived from the committed head, and the browser re-sets `index` to
+  that value on every write. A local `+1` would be WRONG because one action can
+  advance the head by 2 (`file_edit` runs first inside `ran_tests`/`file_*`, so it
+  can commit its own event before the main one). Two remaining paths still compute
+  the index locally with `incrementIndex()`: (a) auto-revert on a wrong prediction
+  (`revert()` in `_run_tests.erb`, POST `/kata/revert`); (b) the `[checkout]` and
+  `[revert]` buttons (both call `cd.revertOrCheckout` in
+  `review/_checkout_button.erb`, POST `/kata/checkout`). These are always +1
+  (`reverted`/`checked_out` commit exactly one event - they do NOT call `file_edit`
+  first, unlike `ran_tests`/`predicted_*`/`file_*`), so the local `+1` is already
+  correct and there is NO bug. Phase 3 still switches them to
+  `setIndex(data.light.index + 1)` (each response already carries
+  `light.index == next_index - 1`) purely for consistency with Option C's principle
+  that the browser adopts the saver-returned index rather than computing a position
+  itself; this is behavior-neutral, not a fix. Once both call sites re-set from the
+  response, `incrementIndex` (`_index.erb`) is dead and is removed. What Phase 3
+  removes is the
+  Option A recovery apparatus: `resyncIndex` and its `.catch(() => resyncIndex())`,
+  so the browser stops CALLING the `next_index` route (the route itself is removed
+  later, in Phase 4). On a lost response the browser leaves `index` stale; the
+  saver self-lag-accepts the next write (same `laptop_id`) and a refresh re-syncs
+  via `edit.erb`. Keep sending `index` (the observed high-water mark) purely as the
+  detection signal. Phase 3 must preserve the invariant that a saver failure still
+  returns the runner's traffic-light (the `run_tests` rescue - see "What does NOT
+  drop away").
+- Phase 4 (contract, after a soak so no old-JS browser still calls it): remove the
+  `GET /kata/next_index/:id` route and its test `kata_next_index_test.rb`. (The
+  old `mobbing_resync_after_lost_event_test.rb` was already re-worked in Phase 3
+  into `mobbing_self_lag_after_lost_event_test.rb`, which asserts the saver
+  self-lag path and STAYS.)
+- Verify Phase 3 by driving the stack (see "How to verify locally"): a lost
+  inter-test response followed by a [test] shows no dialog; a genuine two-laptop
+  interference still does.
+
+## The problem
+
+The "mobbing?" dialog is meant to fire only when two or more laptops share a
+kata-id and their [test] submissions interfere. Today a single user working alone
+can trigger it. The browser owns its next-event `index` (a hidden field) and
+advances it only from a successful response, so a lost or aborted inter-test
+response, whose event the saver still committed, leaves the browser's index behind
+the committed head. The next [test] sends that stale index, which the saver
+rejects as an `"Out of order event"` and the browser renders as a false dialog.
+(nginx rate-limiting is not involved: a 429 is rejected before it reaches the
+saver, so it never commits and never desyncs the index.)
+
+## The idea
+
+Today the browser-sent `index` does double duty: it decides where the event is
+written (correctness) AND it is the mobbing signal (a mismatch raises
+`"Out of order event"`). That coupling is the root of the whole false-positive
+class. Option C splits them:
+
+- Correctness (placement): when a write is accepted it is placed at `last + 1`,
+  server-decided; the browser's index never decides placement. A lost response
+  can no longer poison anything, because the browser never asserts a position
+  that can be wrong.
+- Detection: becomes its own explicit check, driven by per-laptop identity rather
+  than by an index mismatch (see "Detection" below) - and it, not a stale index,
+  is what can reject a write.
+
+## The two halves behave differently
+
+- The correctness half ("append at last+1, ignore the browser index") would
+  function on its own: nobody ever gets a spurious `"Out of order event"` again.
+- But it is NOT shippable on its own, because that index check IS today's entire
+  mobbing detection. Remove it and append blindly, and two genuinely-sharing
+  laptops interleave their events silently, with no dialog ever. That fixes the
+  false positive by deleting the feature.
+
+So Option C requires a replacement detection signal that does not rely on an
+index mismatch. That signal is per-laptop identity: stamp each event with the id
+of the laptop that wrote it, so the saver can tell one laptop's events from
+another's. This id machinery is part of C.
+
+## Per-laptop id
+
+A per-browser id, minted and set as a cookie exactly like the existing
+`csrf_token` in `app.rb` (read the cookie; if absent generate `SecureRandom.hex`
+and Set-Cookie). It is:
+
+- stable across reloads (persists), so a refresh keeps the same id;
+- distinct per browser, so two laptops get different ids;
+- independent random, so it is not derivable from kata-id or avatar (which are
+  shared during genuine mobbing) and can actually distinguish two laptops;
+- sent automatically on every request, no per-fetch wiring.
+
+The web layer forwards it to the saver on each write, so every event is stamped
+with the laptop that wrote it. Default to a session-scoped cookie (cleared on
+browser close), which is enough for stability across reloads.
+
+## Detection
+
+Every committed event is stamped with the writing laptop's id (the cookie above).
+
+Detection needs NO new argument: it reuses the `index` the browser already sends
+on every write. That `index` is the position the browser thinks its next write
+takes - one past the highest committed index it has observed. C stops treating
+`index` as authoritative for PLACEMENT but keeps receiving it and reuses it as
+the detection signal.
+
+The saver, on each write, first inspects the committed events in `index .. head`
+(the events that landed since this browser last looked) to decide the verdict:
+
+- range empty (`index == head + 1`), or every event in it written by THIS
+  `laptop_id` (the browser's own not-yet-observed writes) -> no mobbing ->
+  append the new event at `last + 1` (server-authoritative placement, ignoring
+  the client `index`), return `next_index`, no dialog.
+- any event in the range written by a DIFFERENT `laptop_id` -> another laptop got
+  in -> genuine mobbing -> REJECT: do not append, `events.json` is unchanged, and
+  the write response carries the mobbing dialog (same outcome as today).
+
+So placement is server-authoritative (`last + 1`) on an accepted write, and a
+stale client `index` alone never rejects a write - only a differing `laptop_id`
+in the range does. This preserves today's invariant that a genuinely-interfering
+write is never persisted, while removing the solo lost-response false positive
+(range non-empty but entirely the browser's own id).
+
+Because `index` already carries this, no separate marker and no per-laptop
+server-side cursor is needed; the browser keeps sending `index`, demoted from
+authoritative-position to detection signal.
+
+## What drops away (the win)
+
+- The browser index being AUTHORITATIVE FOR PLACEMENT. Today the saver requires
+  `index == last + 1` and writes at the client's `index`; under C the saver decides
+  placement itself (`head + 1`) and ignores the client `index` for placement. The
+  `index` field STAYS and so does the response-driven re-set:
+  `setIndex(light.index + 1)` in `_run_tests.erb` and
+  `.then(newIndex => setIndex(newIndex))` in `_file_inter_test_events.erb` re-sync
+  the browser to the `next_index` the saver returns (derived from the committed
+  head), so `index` keeps tracking the highest committed index the browser has
+  observed - which IS the saver-returned value. This re-set is REQUIRED, not
+  removed: one logical action can advance the head by 2 (`file_edit` runs first
+  inside `ran_tests`/`file_*`), so a local `+1` would drift. What changes is only
+  the MEANING of the value - a detection high-water mark, no longer an authoritative
+  write position. `setIndex` is kept (the page-load reset in `edit.erb` and the
+  per-write re-set); `incrementIndex` is removed once its `revert()` /
+  `cd.revertOrCheckout` call sites switch to `setIndex`.
+- The entire desync class and everything built to cope with it, including all the
+  Option A machinery: the `GET /kata/next_index/:id` route (`app.rb`) and
+  `resyncIndex` (`_file_inter_test_events.erb`) exist ONLY because the browser
+  owns the index. Under C they are dead and are deleted, along with the route test
+  `kata_next_index_test.rb`. (The resync-recovery test
+  `mobbing_resync_after_lost_event_test.rb` was re-worked in Phase 3 into
+  `mobbing_self_lag_after_lost_event_test.rb`, which asserts the saver self-lag
+  path C relies on and STAYS.) The route is net-new (added
+  for Option A this session), so its complete consumer set is the code that was
+  added with it; removing it touches no other repo and needs no nginx change.
+- The saver's client-supplied index check (`index == last['index'] + 1`) as a
+  correctness gate.
+
+Removal order matters: C drops the browser-owned index, which makes `resyncIndex`
+meaningless, and only then is the `next_index` route dead. The route cannot be
+removed while the client still calls it.
+
+## What does NOT drop away
+
+- The concurrency machinery stays. "Append at head + 1" is computed server-side,
+  but two concurrent writes to one kata still both observe `head = N` and both try
+  to write `N + 1`. The in-process-git compare-and-swap in `commit_event`
+  (documented in `saver` `config/puma.rb` and `docs/in-process-git.md`) is what
+  serializes them. It has nothing to do with the client index and must remain.
+  GAP - NOT yet implemented (do not assume otherwise): the `laptop_id` self-lag
+  verdict lives ONLY inside the `commit_on_main` block (the sequential path). The
+  CAS loser is handled by `commit_event`'s method-level `rescue`, which re-reads
+  the tip and, if it advanced to `>= index`, raises "Out of order event" with NO
+  `laptop_id` check and NO retry. So two CONCURRENT writes from the SAME laptop
+  (eg cause 1: a `[test]` fired by `waitForITE`'s 2s bail while an inter-test event
+  is still in flight) reject the loser as mobbing -> false dialog. Fully closing
+  this needs the CAS-loss rescue to run the same `laptop_id` verdict over
+  `index .. head` and, when the racing events are all this same laptop's own, RETRY
+  the append at the new `head + 1` (only a DIFFERENT laptop_id should reject). Until
+  that retry exists, the concurrent same-laptop case is NOT covered by self-lag; the
+  web-side alternative is to stop the concurrency (do not let `waitForITE` fire
+  `[test]` while an inter-test write is in flight).
+- The `index` field on the wire stays - it IS the detection signal (no separate
+  marker, no server-side cursor; see "Detection"). It changes role from
+  "authoritative next-write position" to "high-water mark I have observed", used
+  only for detection. So the
+  accurate framing is "the browser stops OWNING the index", not "the index is
+  gone".
+- The per-laptop id machinery (the cookie above).
+- INVARIANT: a saver failure never loses the runner result. `run_tests`
+  (`app.rb` ~155-216) runs the runner first, then wraps ONLY the saver save in
+  `begin ... rescue SaverService::Error`, and returns the runner's traffic-light
+  (outcome/stdout/stderr) in the response regardless - so if the saver is down or
+  rejects the write, the browser still shows the light; it is just not persisted
+  (lost on refresh). C surfaces its reject-on-mobbing through this same
+  `SaverService::Error` path, so the behaviour is preserved for free. But Phase 3
+  reworks `run_tests`'s index handling (it currently fabricates
+  `next_index = index + 1` from the sent index on the rescue path), so that rework
+  MUST keep the run-runner-then-rescue-the-save structure and keep returning the
+  light on failure. Treat this as an invariant to test, not an accident to
+  inherit.
+
+## Where the trickiness relocates
+
+From client sync code into the server detection check. Today detection is a free
+side effect of the append failing; under C it is explicit logic ("head moved past
+the browser's `index`, and an intervening event carries a different laptop_id ->
+dialog"). That is the part with regression risk: get it slightly wrong and you
+either miss real mobbing or reintroduce false ones. Net trickiness likely goes
+down, but it moves rather than vanishes.
+
+## Handoff and browser-switch (must still hold under C)
+
+A legitimate handoff or same-laptop browser-switch re-enters the kata and loads
+the edit page, which renders current state and sets the browser's `index` to
+`head + 1`. So the taking-over browser's `index .. head` range is empty and no
+dialog fires, regardless of id. This is the same "a session that re-syncs is
+fine" invariant. If the OLD browser is left open and used again after the new one
+committed events, its `index` is now behind the head and the intervening events
+carry a different id, so it is correctly flagged: two live sessions interfering is
+what the dialog is for.
+
+## Edge cases
+
+- Two tabs, one laptop: same cookie, same id, treated as self (no dialog). Matches
+  the feature's intent ("two or more laptops").
+- Cookie cleared / incognito / new browser mid-kata: new id, but the page load
+  sets `index` to `head + 1`, so the range is empty and the id is never examined.
+- Legacy events (committed before C ships, no laptop_id): the saver cannot prove
+  an intervening event is "mine", so it must fail toward the dialog, which is
+  today's behavior. Backward compatible and safe (never silently interleave two
+  real laptops).
+
+## Rollout plan (expand / contract)
+
+Only web and saver change (nginx and the other services are untouched). The
+sequence is expand/contract so mobbing detection is never silently lost mid-deploy.
+
+Two ordering facts, in tension, fix the sequence:
+
+- The saver REJECTS an unknown `laptop_id` keyword (the governing constraint at the
+  top of this doc: strict-kwarg dispatch -> HTTP 500). So the saver must ACCEPT the
+  field before web sends it.
+- The saver cannot originate `laptop_id` (it is a web-minted cookie). So the saver
+  cannot store or act on it until web is sending it.
+
+Together these mean: saver-accepts first, then web-sends, then saver-stores/acts.
+Each step is safe against the deployed version of the other side.
+
+Phase 1 - capture (prime the data), no user-visible change:
+
+- Step 1.1 saver (deploy first): add an optional `laptop_id: nil` keyword to the 9
+  event-committing write methods in `model.rb` (`kata_file_create`,
+  `kata_file_delete`, `kata_file_rename`, `kata_file_edit`, `kata_ran_tests`,
+  `kata_predicted_right`, `kata_predicted_wrong`, `kata_reverted`,
+  `kata_checked_out`) so the dispatch no longer raises on the extra key. Do NOTHING
+  with the value yet - accept and drop it. Detection is unchanged (still the index
+  check, still raises today). This is the "expand" that lets web send the field
+  safely; it is a no-op for both old web (no field) and new web (field present).
+- Step 1.2 web (deploy after saver is live): mint the `laptop_id` cookie in
+  `app.rb`, mirroring the `csrf_token` block (read the cookie; if absent mint
+  `SecureRandom.hex(32)` and Set-Cookie), then forward `laptop_id` to the saver on
+  all 9 event-writes. Forward only `laptop_id` (the browser already sends `index`);
+  detection is deferred to Phase 2. Change nothing else: the browser still owns and
+  sends the authoritative index, `resyncIndex` and the `next_index` route stay.
+  Safe because Step 1.1 already made the saver accept the field.
+- Step 1.3 saver (deploy after web is live): store `laptop_id` on each committed
+  event, but only when it is well-formed - the 64-char lowercase-hex minted
+  format (`SecureRandom.hex(32)`, validated at the saver, which owns the log and
+  does not trust input). A nil, absent, or malformed laptop_id stores NO
+  `laptop_id` key at all, so such an event is indistinguishable from a legacy
+  pre-1.3 event - there is a single representation of "unknown writer" (key
+  absent), never a stored `null` or untrusted value. The value is threaded through the write
+  path to the one commit point (`kata_v2.rb` `commit_event`) and added to the
+  stored event beside `index`/`time`; the index-0 create event is written by
+  `kata_create`, not this path, so it carries no `laptop_id`. Detection is still
+  unchanged - the saver only records who wrote each event. Note the `laptop_id: nil`
+  default on the web-facing methods is transitional: once all clients send a
+  laptop_id, that default is removed and the field becomes required. Design this
+  step only once 1.1 and 1.2 are in place; events written between 1.2 and 1.3
+  carry no stored id and are treated as legacy.
+- Net effect: events begin carrying the writing laptop's id; users see no change;
+  the history needed for detection starts accumulating.
+
+Phase 2 - saver, switch detection to dual-mode: DONE (implemented + tested in the
+saver working tree, undeployed). `commit_event` uses the `laptop_id` verdict
+(inspect `index .. head`) when `laptop_id` is present; otherwise it falls back to
+today's index check (`if laptop_id.nil?` branch - legacy events or requests
+without a laptop_id). In the new mode an accepted write is placed at `last + 1`
+(the client `index` never decides placement), and a differing `laptop_id` in the
+range rejects the write (not saved) exactly as today. The only behaviour change
+is more-permissive: the solo lost-response case (range all the browser's own id)
+now succeeds instead of being rejected; genuine mobbing is rejected as before.
+Also: `git_commit_tag_sss`'s `next_index` is now derived from the committed head
+(`all_events.last['index'] + 1`) and the tag from `place_at`, so an accepted
+stale write reports the real next index. Tests in `kata_mobbing_detection.rb`.
+
+Phase 3 - web, stop the browser OWNING the index for placement: rely on the
+server-decided placement (`head + 1`) plus the rejection verdict (the
+`out_of_sync` dialog). KEEP re-setting `index` to the saver-returned `next_index`
+on every write (the `setIndex` calls in `_run_tests.erb` and
+`_file_inter_test_events.erb`) - that is how the browser tracks the committed head,
+and a local `+1` would drift because one action can be +2. For consistency (the
+browser adopts the saver-returned index, never computes locally), also switch the two
+paths that still use a local `incrementIndex()` - `revert()` (auto-revert on a wrong
+prediction) and `cd.revertOrCheckout` (the `[checkout]`/`[revert]` buttons) - to the
+same `setIndex(data.light.index + 1)`, then remove the now-dead `incrementIndex`.
+These paths are always +1 (`reverted`/`checked_out` do NOT call `file_edit`), so this
+is behavior-neutral cleanup, not a fix. Remove the Option A recovery:
+`resyncIndex` and its `.catch(() => resyncIndex())`, so the browser stops calling the
+`next_index` route (the route is removed in Phase 4). The browser still
+sends `laptop_id` + `index`, but `index` is now a detection high-water mark, not an
+authoritative write position. Safe once Phase 2 is live, because the saver already
+places at `head + 1` for id-bearing requests.
+
+Phase 4 - contract, cleanup (after a soak so no old-JS browser session can still
+call `next_index`): web removes the `next_index` route and its test
+`kata_next_index_test.rb`; saver removes the old index check, collapsing dual-mode
+to single-mode. (`mobbing_resync_after_lost_event_test.rb` is not removed here - it
+was re-worked in Phase 3 into `mobbing_self_lag_after_lost_event_test.rb`.)
+
+## Deploy safety
+
+Both web and saver change, so both crossovers matter.
+
+- A normally-progressing user has an empty `index .. head` range (index ==
+  head + 1), so the detection logic is a no-op for them and they see no change.
+- A stale range over legacy events falls back to today's behavior (dialog).
+- The `laptop_id` field is NOT silently ignored by an unprepared saver: its
+  strict-kwarg dispatch raises HTTP 500 on an unknown key (see the constraint at
+  the top of this doc). Safety therefore comes from ordering, not from the field
+  being inert - Step 1.1 makes the saver accept `laptop_id` before Step 1.2 has web
+  send it, so no crossover ever has web sending a field the deployed saver rejects.
+  Once accepted, the field is additive at the storage layer: it is stored only
+  when present, so old (legacy) events and nil-write events alike simply have no
+  `laptop_id` key, which reads back as absent/nil; no migration, `events.json`
+  stays the single source of truth both versions read.
+- The invariant to enforce: the id/index detection logic may only make the saver
+  MORE permissive than today, never less. No write that succeeds today may fail
+  after C lands.
+- The dropped `next_index` route: an old browser (pre-C web) still calls it, so the
+  route must not be removed until no deployed browser session can still call it.
+  That is why it is a Phase 4 (contract) step, gated on a soak, not part of the
+  Phase 3 web deploy that stops calling it. See the Rollout plan above.
+
+## Assumptions
+
+- Event indices are contiguous `0..N`, so `head == last_index` and
+  `events.length == last_index + 1`.
+- The saver is the single source of truth for a kata's committed state.
+- `laptop_id` identifies a browser/laptop, not a kata or avatar, and is stable
+  across reloads (a cookie).
+- The `index` the browser sends is truthful: one past the highest committed index
+  it has rendered (set to `head + 1` on page load).
+
+## Tests to write when building Option C
+
+- Accepted-write placement ignores a stale client index: with the range all the
+  browser's own id (or empty), a write whose client index is stale/absent is still
+  appended at `head + 1`, not the client index.
+- Detection: an empty `index .. head` range is accepted, no dialog (normal
+  progress and refreshed handoff).
+- Detection: a range whose events all carry the requester's laptop_id is accepted,
+  no dialog (the browser's own not-yet-observed writes, the old desync scenario).
+- Detection: a range containing a different laptop_id is REJECTED and not saved,
+  with the dialog (genuine two-laptop interference) - `events.json` unchanged.
+  (Concurrency caveat: this self-lag verdict runs only in the SEQUENTIAL path. The
+  CAS-loss rescue does NOT yet do it - it rejects any concurrent loser whose tip
+  advanced to `>= index`, same laptop or not. The saver `DccG02` concurrent-saves
+  test asserts the loser fails. Making a same-laptop concurrent loser
+  retry-and-succeed is the UNIMPLEMENTED fix described in the "concurrency
+  machinery" bullet under "What does NOT drop away".)
+- Legacy events (no laptop_id) in the range are rejected (dialog), as today.
+- After C, the `next_index` route and `resyncIndex` are gone (grep is clean); the
+  route test `kata_next_index_test.rb` is removed, and the resync test is re-worked
+  into the self-lag guard `mobbing_self_lag_after_lost_event_test.rb`.
+
+## Code map (current mechanism, the code C changes)
+
+Line numbers are approximate; grep the symbol if they have drifted.
+
+web (`web/source/app/`):
+- `app.rb:155` `post '/kata/run_tests/:id'` - the only handler that surfaces
+  mobbing. It calls the saver, rescues `SaverService::Error`, and at `app.rb:192`
+  sets `@out_of_sync = error.message.include?('Out of order event')`, returned as
+  `out_of_sync:` (`app.rb:213`). The file event routes (`file_create` etc, ~132)
+  do NOT map the error, so only [test] shows the dialog.
+- `app.rb:333` `def index` reads the browser-sent index; `app.rb:342` `ran_tests`
+  dispatches to the saver. C makes the saver ignore this for placement.
+- `app.rb:306` `get '/kata/next_index/:id'` - the Option A stopgap route (delete
+  in Phase 4).
+- `views/kata/_index.erb:13,18` `incrementIndex`/`setIndex` - the browser's index
+  helpers. `setIndex` STAYS (the page-load reset and the per-write re-set to the
+  saver-returned value). `incrementIndex` is removed in Phase 3 once its two call
+  sites (`revert()` and `cd.revertOrCheckout`) switch to `setIndex`.
+- `views/kata/_run_tests.erb` - `setIndex(light.index + 1)` on a successful test
+  (re-sets to the saver-returned index, retained under C); reads the `out_of_sync`
+  flag and shows the dialog (`showAvatarsOutOfSync`). Phase 3 consistency change:
+  `revert()` (`:113`, the auto-revert-on-wrong-prediction path, POST `/kata/revert`)
+  advances via a local `incrementIndex()`. `reverted` commits exactly one event (it
+  does NOT call `file_edit` first), so the local `+1` is already correct - no bug.
+  Switch it to `setIndex(data.light.index + 1)` anyway, so every write path adopts
+  the saver-returned index (Option C's principle); behavior-neutral cleanup.
+- `views/review/_checkout_button.erb:45` `cd.revertOrCheckout` - the shared handler
+  for the `[checkout]` AND `[revert]` buttons (POST `/kata/checkout`). Advances the
+  index via a local `incrementIndex()` (`:69`); `checked_out` is also always +1
+  (no `file_edit`), so this too is correct today. Phase 3 switches it to
+  `setIndex(data.light.index + 1)` for the same consistency reason as `revert()`
+  above.
+- `views/kata/_file_inter_test_events.erb:80` `setIndex(newIndex)` on success -
+  RETAINED (re-sets to the saver-returned index). `:86` `.catch(() => resyncIndex())`
+  and `:90` `resyncIndex` (Option A) are removed in Phase 3 (the `.catch` becomes a
+  no-op; a lost response recovers via saver self-lag + a refresh). Also holds the
+  in-progress flag for every inter-test event.
+- `views/kata/edit.erb:29,35` embeds the events array and runs
+  `setIndex(events.length)` on load - this is the resync-on-refresh that makes
+  handoff safe; under C the same `index` becomes the detection high-water mark.
+
+saver (`saver/source/server/model/kata_v2.rb`) - Phase 2 is implemented here:
+- `commit_event` is the write path. Inside the `commit_on_main` block it branches:
+  `if laptop_id.nil?` keeps today's check (`raise "Out of order event"` when
+  `index != last + 1`, place at `index`); else it sets `place_at = head + 1`,
+  raises when `index > place_at` (ahead) or when any event in `index .. head` has a
+  different `laptop_id` (mobbing), and otherwise accepts (self-lag) - placing the
+  event at `place_at`. The two-layer comment above the method documents this. The
+  method-level `rescue` handles the concurrent (CAS-loss) case: it re-reads the tip
+  via git and rejects the loser when the tip advanced to `>= index` - with NO
+  `laptop_id` check and NO retry, so a concurrent same-laptop loser is falsely
+  rejected (the concurrency GAP under "What does NOT drop away").
+  `valid_laptop_id?` (64-hex) gates whether `laptop_id` is stored on the event.
+- `git_commit_tag_sss` derives `next_index` from `all_events.last['index'] + 1`
+  and `create_tag` uses `place_at`, so an accepted stale write reports/tags the
+  real committed index.
+- `:471` `git update-ref ... <new_oid> <base_oid>` is the compare-and-swap that
+  serializes concurrent writes - the concurrency mechanism that STAYS.
+- `file_edit` (`:238`) runs first inside `ran_tests` (`:262`) and can itself
+  commit an event, so one logical action can advance the head by 2.
+- `config/puma.rb` and `docs/in-process-git.md` document the CAS model.
+- Concurrency proving test: client test `DccG02`
+  (`saver/test/client/kata_concurrent_saves_test.rb`).
+
+nginx (`nginx/nginx.conf.template`): file/test routes are rate-limited
+(`kata_file_* 1r/m`, `kata_file_edit 6r/m`, `run_tests 6r/m` keyed by `$uri`,
+all `nodelay`). No change needed for C. A 429 never reaches the saver.
+
+## How to verify locally
+
+The working tree is served into the containers, but note two gotchas that cost
+time otherwise:
+
+- `web-web-1` runs Puma in production mode (no auto-reload). After editing
+  `app.rb` you must `docker restart web-web-1` for a route change to take effect.
+  Mounted `.erb` views re-render per request, so view edits are live.
+- The saver does NOT refresh its git working tree on write (reads go via git). To
+  see a kata's real committed state, read through git, not the file:
+  `docker exec web-saver-1 bash -c "cd /cyber-dojo/katas/<P1>/<P2>/<P3> && git show main:events.json | jq ."`
+  (a kata id `abcdef` maps to `ab/cd/ef`). `cat events.json` shows STALE data.
+
+Bring up the full stack (nginx + web + saver + deps), which activates the real
+rate-limiting layer:
+
+```
+cd web && make demo          # builds web, creates a seeded v2 kata, opens it
+```
+
+`create_v2_kata.rb` seeds a kata with a full demo history (head at index 11), not
+an empty one. Make a fresh one for a clean run:
+
+```
+docker exec --env CYBER_DOJO_SAVER_CLASS=SaverService web-web-1 \
+  bash -c "ruby /web/source/script/create_v2_kata.rb 1"   # prints the new id
+```
+
+Drive the saver JSON API directly (port 4537 inside the container; no curl in the
+saver image, so use ruby Net::HTTP): POST `/kata_ran_tests`, `/kata_file_create`,
+etc with a JSON body `{id:, index:, files:, ...}`. On an out-of-order the saver
+returns HTTP 500 with body `{"exception":"Out of order event for <id>"}`.
+
+Run one controller test file against the running saver (RunnerStub avoids the real
+runner); do NOT use `bin/run_tests.sh`, which tears the stack down and up:
+
+```
+docker exec --user nobody \
+  -e RACK_ENV=test -e CYBER_DOJO_SAVER_CLASS=SaverService \
+  -e CYBER_DOJO_RUNNER_CLASS=RunnerStub \
+  -e COVERAGE_DIR=/tmp/cyber-dojo/coverage/app_controllers \
+  web-web-1 sh -c 'mkdir -p /tmp/cyber-dojo/coverage/app_controllers && \
+    cd /web/source/test/app_controllers && \
+    ruby -e "require \"../test_coverage.rb\"; require \"./<file>_test.rb\"" app_controllers'
+```
+
+Or the whole module (no stack teardown):
+`docker exec --user nobody web-web-1 sh -c 'cd /web/source/test && ./run.sh app_controllers'`.
+
+Already verified this way in the design session: the false-mobbing reproduction
+(stale index -> HTTP 500 out-of-order) and the handoff baseline (Laptop A drove a
+kata to head 11; Laptop B's refresh synced to index 12 and its [test] saved
+cleanly; the same [test] at the pre-refresh index 11 raised out-of-order).

--- a/docs/mobbing-web-index-desync-causes.md
+++ b/docs/mobbing-web-index-desync-causes.md
@@ -1,0 +1,217 @@
+# Mobbing false-positive: web-side causes still live after #381
+
+Status: findings, not yet code changes. This catalogs THREE distinct web-side
+causes that can still raise the false "mobbing?" dialog for a single browser
+driving a kata-id - no second laptop is actually interfering - on the code
+that includes #381 (Option A: the `GET /kata/next_index/:id` route, the client
+`resyncIndex`, and the inter-test fetch abort raised from 2s to 30s). All three
+are in web's code (the browser mismanages its own `index`); the saver's only role
+is to correctly reject the resulting bad index. See
+`mobbing-server-owned-index-design.md` (Option C) and
+`mobbing-laptop-id-design.md` for the surrounding design.
+
+## The report
+
+A trusted instructor running group sessions (many avatars) still gets the false
+"mobbing?" dialog on the deployed Option A code. So #381 did not fix the problem
+for them. The dialog is false because each affected kata-id is driven by a single
+browser mismanaging its own `index`, not by two laptops genuinely interfering on
+that kata-id.
+
+## Summary of causes
+
+The dialog fires whenever a `[test]` reaches the saver with an `index` that is
+not `committed_head + 1`. That happens two ways: the browser index falls BEHIND
+the head, or it runs AHEAD of it.
+
+- Cause 1 - `waitForITE` 2s bail-out. Index falls BEHIND. Fixed by Option C.
+- Cause 2 - `run_tests` rescue path fabricates `index + 1` on a non-out-of-order
+  saver error. Index runs AHEAD. NOT fixed by Option C (an ahead index is still
+  rejected), and the uncommitted working tree leaves this path unchanged.
+- Cause 3 - a lost/aborted `[test]` response the saver still committed. Index
+  falls BEHIND. Fixed by Option C; NOT fixed by #381 (Option A only resynced
+  inter-test events, never the `[test]` path).
+
+Cause 2 is the one that needs a web fix regardless of Option C.
+
+## Cause 1 - the second 2-second timeout (`waitForITE`)
+
+#381 raised ONE 2-second timeout (the inter-test `fetch` abort, now 30s) but
+left a SECOND, independent 2-second timeout untouched, and that second one is the
+live trigger.
+
+The `[test]` button is not fired directly. `_test_button.erb:11` gates it behind
+an in-progress inter-test event:
+
+```js
+$button.click(() => cd.waitForITE(() => kata.testButton.click()));
+```
+
+`cd.waitForITE` (`_file_inter_test_events.erb`) polls `_interTestEventInProgress`
+but abandons the wait after `maxWait = 2000` ms and runs the callback regardless:
+
+```js
+const pollInterval = 50;
+const maxWait = 2000;
+let elapsed = 0;
+const poll = setInterval(() => {
+  elapsed += pollInterval;
+  if (!_interTestEventInProgress || elapsed >= maxWait) {
+    clearInterval(poll);
+    callback();
+  }
+}, pollInterval);
+```
+
+Mechanism:
+
+1. During normal editing of a kata an inter-test file event fires (selecting a file
+   `_filenames.erb:130`, clicking a traffic light `_traffic_lights.erb:42`, a
+   file create/delete/rename `_file_create_rename_delete.erb`, download, etc).
+   It sets `_interTestEventInProgress = true` and POSTs at the current
+   `kata.index`, advancing the index ONLY when its response arrives via
+   `kata.setIndex(newIndex)`.
+2. #381 lets that event run for up to 30s (its own abort is now 30s). If it
+   takes longer than 2s and the user clicks `[test]`, `waitForITE` gives up at
+   2000ms and fires the test while the event is still in flight, so `kata.index`
+   is still stale (behind the head).
+3. The saver commits the inter-test event (the committed head advances). The
+   `[test]` POST arrives carrying the stale index. On the deployed (Option A)
+   saver a stale index is rejected as an out-of-order event, the
+   `/kata/run_tests` handler maps that to `out_of_sync: true`, and
+   `_run_tests.erb` renders it as the "mobbing?" dialog (`showAvatarsOutOfSync`).
+
+So raising the fetch abort from 2s to 30s actually WIDENED the window:
+inter-test events are now allowed to run up to 30s, but `waitForITE` still
+abandons its wait at 2s and lets `[test]` race ahead with a stale index. Same
+2-second root cause, a different timer that #381 did not touch. This is the
+"slow-[test]-retry case Option A never closed" referred to in
+`mobbing-server-owned-index-design.md` (the KEY FRAMING paragraph).
+
+Fixed by Option C: the `[test]` carries the SAME laptop's `laptop_id`, so the
+events in the stale `index .. head` range are all the user's own in-flight write.
+The saver classifies this as self-lag, accepts it, and shows no dialog. The
+in-process-git compare-and-swap serializes the two concurrent same-laptop writes
+and places both correctly.
+
+## Cause 2 - `run_tests` rescue path advances the index on a non-out-of-order saver error
+
+`app.rb` `post '/kata/run_tests/:id'` (deployed and unchanged in the working
+tree):
+
+```ruby
+rescue SaverService::Error => error
+  next_index  = index + 1          # fabricated even though NOTHING committed
+  major_index = index + 1
+  minor_index = ''
+  @saved = false
+  $stdout.puts(error.message)
+  $stdout.flush
+  @out_of_sync = error.message.include?('Out of order event')
+end
+```
+
+If the saver save raises ANY `SaverService::Error` whose message is not
+`'Out of order event'` (the saver restarting or overloaded, a connection reset, a
+500), then `@out_of_sync` is false and the response carries `out_of_sync: false`
+with a fabricated `next_index = index + 1`. In `_run_tests.erb`, `handleResponse`
+takes the `else` branch and calls `refreshFromTest`, which does:
+
+```js
+cd.kata.setIndex(light.index + 1);   // light.index == next_index - 1 == index
+```
+
+so the browser advances to `index + 1`. But nothing was committed - the head is
+unchanged. The browser index is now ONE AHEAD of the head. The very next
+`[test]` sends an ahead index, which the saver rejects as out-of-order, and the
+browser shows the false dialog.
+
+This is a two-step failure: a transient saver hiccup silently ARMS the desync,
+and the next `[test]` FIRES the dialog. A browser refresh clears it
+(`edit.erb` resets `index` to `events.length`), so it presents as an
+intermittent false dialog with no obvious trigger.
+
+NOT fixed by Option C. Under Option C the saver places a write at `head + 1` and
+still rejects an index that is AHEAD of that (`raise when index > head + 1`), so
+the ahead index from this path is still rejected. The uncommitted working tree
+leaves this rescue block unchanged (it adds `laptop_id` and switches `revert()`
+to `setIndex`, but does not touch the fabricated `+1`). The fix is web-side and
+independent: do not advance the browser index when the save did not commit (eg
+do not `setIndex` when `@saved == false`, or stop fabricating `next_index` on the
+rescue path and signal the client not to advance).
+
+## Cause 3 - a lost or aborted `[test]` response the saver still committed
+
+`_run_tests.erb` `runTests` aborts the `[test]` POST after 30s and, on any
+fetch failure, shows a generic error dialog without touching the index:
+
+```js
+const timer = setTimeout(() => controller.abort(), 30000);
+...
+.then(handleResponse)
+.catch(err => cd.dialogError(err.message))   // generic dialog; no setIndex, no resync
+.finally(() => { clearTimeout(timer); cd.waitSpinner.fadeOut('slow', onComplete); });
+```
+
+If the `[test]` POST is lost client-side (the 30s abort on a slow runner-plus-save,
+or a network drop) but the saver commits, the head advances while the browser
+index stays put (behind the head). The next `[test]` sends the stale index and
+the saver rejects it as out-of-order - the false dialog. Like cause 2 this is a
+two-step failure: the lost response shows only a generic error, and the NEXT
+`[test]` shows "mobbing?".
+
+This is exactly the lost-response problem #381 fixed for INTER-TEST events - but
+the fix (`resyncIndex`) was only wired into `syncPostWithCallbackITE`. The
+`[test]`/`run_tests` path never got a resync, so it was never covered.
+
+Fixed by Option C: the stale `[test]` carries the same `laptop_id`, the
+`index .. head` range is all the user's own committed `ran_tests` event, so the
+saver self-lag-accepts it and a refresh re-syncs. NOT fixed by #381.
+
+(A 429 from nginx rate-limiting does NOT cause this: a 429 is rejected before it
+reaches the saver, so nothing commits, the head does not move, and the index
+stays correct. The `[test]` fetch just shows a generic error dialog.)
+
+## Decision this drives
+
+- Deploying the saver (Option C Phases 1+2) plus web sending `laptop_id` closes
+  causes 1 and 3 (both "behind head", both become self-lag accepts). Nothing in
+  these findings is a reason to delay that saver deploy; saver-first is the
+  design's required order and is what unblocks the fix.
+- Cause 2 must be fixed in web regardless, because an ahead index is still
+  rejected under Option C. This fix is small and local to the `run_tests` rescue
+  path and `refreshFromTest`.
+- Cause 1's `waitForITE` 2s cap: if Option C is imminent, patching it is
+  throwaway work (Option C makes it benign and Phase 3 does not touch it). If
+  Option C is NOT imminent, align the two timeouts via a single shared constant
+  (eg `INTER_TEST_TIMEOUT_MS = 30000`) used for both the fetch abort and
+  `waitForITE`'s `maxWait`, removing the class of bug (two coupled timeouts that
+  drifted apart) rather than just this instance. The `finally` block already
+  clears `_interTestEventInProgress` on every outcome, so `waitForITE` unblocks
+  with a correct index IF it waits long enough.
+
+## Note for the Option C plan
+
+`mobbing-server-owned-index-design.md` (Phases 3-4) never mentions `waitForITE`
+or its 2s `maxWait`. That is fine for correctness under Option C (cause 1 becomes
+benign), but the coupled-timeout smell (a 2s gate guarding a 30s operation)
+survives into the Option C end-state as dead-but-confusing code. Worth a one-line
+note there that the cap is intentionally left as a harmless UI debounce, so a
+future reader does not rediscover it as a "bug". The plan should also add cause 2
+as an explicit web fix, since Option C does not cover it.
+
+## Code map
+
+- `source/app/app.rb` - `post '/kata/run_tests/:id'`: the rescue block that
+  fabricates `next_index = index + 1` (cause 2) and maps the out-of-order error
+  to `out_of_sync:`; `get '/kata/next_index/:id'` is the Option A route.
+- `source/app/views/kata/_run_tests.erb` - `runTests` `.catch` with no resync
+  (cause 3); `refreshFromTest` does `setIndex(light.index + 1)` (cause 2); reads
+  `out_of_sync` and shows the dialog (`showAvatarsOutOfSync`).
+- `source/app/views/kata/_file_inter_test_events.erb` - `cd.waitForITE`
+  (`maxWait = 2000`, cause 1) and `syncPostWithCallbackITE` (30s fetch abort,
+  sets and clears `_interTestEventInProgress`).
+- `source/app/views/kata/_test_button.erb:11` - `[test]` gated behind
+  `cd.waitForITE` (cause 1).
+- `source/app/services/saver_service.rb` - `kata_ran_tests` (and the other 8
+  write methods) carry `laptop_id` in the uncommitted Option C work.

--- a/source/app/app.rb
+++ b/source/app/app.rb
@@ -26,6 +26,11 @@ class App < Sinatra::Base
       @csrf_token = SecureRandom.hex(32)
       response.set_cookie('csrf_token', value: @csrf_token, path: '/')
     end
+    @laptop_id = request.cookies['laptop_id']
+    unless @laptop_id
+      @laptop_id = SecureRandom.hex(32)
+      response.set_cookie('laptop_id', value: @laptop_id, path: '/')
+    end
     unless %w[GET HEAD OPTIONS TRACE].include?(request.request_method)
       token = request.env['HTTP_X_CSRF_TOKEN'] || params['authenticity_token']
       halt 403, 'Forbidden' unless token == @csrf_token
@@ -131,22 +136,22 @@ class App < Sinatra::Base
 
   post '/kata/file_create' do
     content_type :json
-    saver.kata_file_create(id, index, params_files, params[:filename]).to_json
+    saver.kata_file_create(id, index, params_files, params[:filename], laptop_id).to_json
   end
 
   post '/kata/file_delete' do
     content_type :json
-    saver.kata_file_delete(id, index, params_files, params[:filename]).to_json
+    saver.kata_file_delete(id, index, params_files, params[:filename], laptop_id).to_json
   end
 
   post '/kata/file_rename' do
     content_type :json
-    saver.kata_file_rename(id, index, params_files, params[:old_filename], params[:new_filename]).to_json
+    saver.kata_file_rename(id, index, params_files, params[:old_filename], params[:new_filename], laptop_id).to_json
   end
 
   post '/kata/file_edit' do
     content_type :json
-    saver.kata_file_edit(id, index, params_files).to_json
+    saver.kata_file_edit(id, index, params_files, laptop_id).to_json
   end
 
   # - - - - - - - - - - - - - - - -
@@ -182,6 +187,7 @@ class App < Sinatra::Base
       next_index  = result['next_index']
       major_index = result['major_index']
       minor_index = result['minor_index']
+      @saved = true
     rescue SaverService::Error => error
       next_index  = index + 1
       major_index = index + 1
@@ -211,6 +217,7 @@ class App < Sinatra::Base
       status:      @status.to_s,
       log:         @log.to_s,
       out_of_sync: @out_of_sync == true,
+      saved:       @saved == true,
       created:     @created,
       changed:     @changed
     }.to_json
@@ -231,7 +238,7 @@ class App < Sinatra::Base
     result = saver.kata_reverted(id, index, @files, @stdout, @stderr, @status, {
       colour: @colour,
       revert: args
-    })
+    }, laptop_id)
     light = json[:light]
     light[:index]       = result['next_index'] - 1
     light[:major_index] = result['major_index']
@@ -253,7 +260,7 @@ class App < Sinatra::Base
     }
     json = source_event(from[:id], from[:index], :checkout, from)
     summary = { colour: @colour, checkout: from }
-    result = saver.kata_checked_out(id, index, @files, @stdout, @stderr, @status, summary)
+    result = saver.kata_checked_out(id, index, @files, @stdout, @stderr, @status, summary, laptop_id)
     light = json[:light]
     light[:index]       = result['next_index'] - 1
     light[:major_index] = result['major_index']
@@ -334,6 +341,12 @@ class App < Sinatra::Base
     params[:index].to_i
   end
 
+  # The per-browser id minted in the before-hook cookie block, forwarded to the
+  # saver on each event-write so it can stamp the writing laptop (mobbing detection).
+  def laptop_id
+    @laptop_id
+  end
+
   def params_files
     data = Rack::Utils.parse_nested_query(params[:data])
     files_from(data['file_content'])
@@ -341,11 +354,11 @@ class App < Sinatra::Base
 
   def ran_tests(id, index, files, stdout, stderr, status, summary)
     if summary[:predicted] === 'none'
-      saver.kata_ran_tests(id, index, files, stdout, stderr, status, summary)
+      saver.kata_ran_tests(id, index, files, stdout, stderr, status, summary, laptop_id)
     elsif summary[:predicted] === summary[:colour]
-      saver.kata_predicted_right(id, index, files, stdout, stderr, status, summary)
+      saver.kata_predicted_right(id, index, files, stdout, stderr, status, summary, laptop_id)
     else
-      saver.kata_predicted_wrong(id, index, files, stdout, stderr, status, summary)
+      saver.kata_predicted_wrong(id, index, files, stdout, stderr, status, summary, laptop_id)
     end
   end
 

--- a/source/app/services/saver_service.rb
+++ b/source/app/services/saver_service.rb
@@ -10,6 +10,7 @@ class SaverService
   end
 
   def initialize(externals)
+    @externals = externals
     hostname = ENV.fetch('CYBER_DOJO_SAVER_HOSTNAME', 'saver')
     port = ENV['CYBER_DOJO_SAVER_PORT'].to_i
     requester = HttpJson::Requester.new(externals.http, hostname, port)
@@ -86,101 +87,110 @@ class SaverService
 
   # - - - - - - - - - - - - - - - - - -
 
-  def kata_file_create(id, index, files, filename)
+  def kata_file_create(id, index, files, filename, laptop_id)
     @http.post(__method__, {
-      id:id, 
+      id:id,
       index:index,
-      files:files, 
-      filename:filename
+      files:files,
+      filename:filename,
+      laptop_id:laptop_id
     })
   end
 
-  def kata_file_delete(id, index, files, filename)
+  def kata_file_delete(id, index, files, filename, laptop_id)
     @http.post(__method__, {
-      id:id, 
+      id:id,
       index:index,
-      files:files, 
-      filename:filename
+      files:files,
+      filename:filename,
+      laptop_id:laptop_id
     })
   end
 
-  def kata_file_rename(id, index, files, old_filename, new_filename)
+  def kata_file_rename(id, index, files, old_filename, new_filename, laptop_id)
     @http.post(__method__, {
       id:id, 
       index:index,
-      files:files, 
+      files:files,
       old_filename:old_filename,
-      new_filename:new_filename
+      new_filename:new_filename,
+      laptop_id:laptop_id
     })
   end
 
-  def kata_file_edit(id, index, files)
+  def kata_file_edit(id, index, files, laptop_id)
     @http.post(__method__, {
-      id:id, 
+      id:id,
       index:index,
-      files:files
+      files:files,
+      laptop_id:laptop_id
     })
   end
 
   # - - - - - - - - - - - - - - - - - -
 
-  def kata_ran_tests(id, index, files, stdout, stderr, status, summary)
+  def kata_ran_tests(id, index, files, stdout, stderr, status, summary, laptop_id)
     @http.post(__method__, {
-      id:id, 
+      id:id,
       index:index,
-      files:files, 
-      stdout:stdout, 
-      stderr:stderr, 
+      files:files,
+      stdout:stdout,
+      stderr:stderr,
       status:status,
-      summary:summary
+      summary:summary,
+      laptop_id:laptop_id
     })
   end
 
-  def kata_predicted_right(id, index, files, stdout, stderr, status, summary)
+  def kata_predicted_right(id, index, files, stdout, stderr, status, summary, laptop_id)
     @http.post(__method__, {
-      id:id, 
+      id:id,
       index:index,
-      files:files, 
-      stdout:stdout, 
-      stderr:stderr, 
+      files:files,
+      stdout:stdout,
+      stderr:stderr,
       status:status,
-      summary:summary
+      summary:summary,
+      laptop_id:laptop_id
     })
   end
 
-  def kata_predicted_wrong(id, index, files, stdout, stderr, status, summary)
+  def kata_predicted_wrong(id, index, files, stdout, stderr, status, summary, laptop_id)
     @http.post(__method__, {
-      id:id, 
+      id:id,
       index:index,
-      files:files, 
-      stdout:stdout, 
-      stderr:stderr, 
+      files:files,
+      stdout:stdout,
+      stderr:stderr,
       status:status,
-      summary:summary
+      summary:summary,
+      laptop_id:laptop_id
     })
   end
 
-  def kata_reverted(id, index, files, stdout, stderr, status, summary)
+  def kata_reverted(id, index, files, stdout, stderr, status, summary, laptop_id)
     @http.post(__method__, {
-      id:id, 
+      id:id,
       index:index,
-      files:files, 
-      stdout:stdout, 
-      stderr:stderr, 
+      files:files,
+      stdout:stdout,
+      stderr:stderr,
       status:status,
-      summary:summary
+      summary:summary,
+      laptop_id:laptop_id
     })
   end
 
-  def kata_checked_out(id, index, files, stdout, stderr, status, summary)
+  def kata_checked_out(id, index, files, stdout, stderr, status, summary, laptop_id)
     @http.post(__method__, {
-      id:id, 
+      id:id,
       index:index,
-      files:files, 
-      stdout:stdout, 
-      stderr:stderr, 
+      files:files,
+      stdout:stdout,
+      stderr:stderr,
       status:status,
-      summary:summary
+      summary:summary,
+      laptop_id:laptop_id
     })
   end
 
@@ -193,4 +203,5 @@ class SaverService
   def diff_lines(id, was_index, now_index)
     @http.get(__method__, {id:id, was_index:was_index, now_index:now_index})
   end
+
 end

--- a/source/app/views/kata/_file_inter_test_events.erb
+++ b/source/app/views/kata/_file_inter_test_events.erb
@@ -78,22 +78,14 @@ document.addEventListener('DOMContentLoaded', () => {
     })
     .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
     .then(newIndex => kata.setIndex(newIndex))
-    // If the response is lost (aborted, network drop) the saver may still
-    // have committed the event, leaving kata.index stale. Sending that stale
-    // index on the next [test] is what the saver reports as an out-of-order
-    // event and the browser shows as a false 'mobbing?' dialog. Resync
-    // kata.index to the committed head so the next save is in step.
-    .catch(() => resyncIndex())
+    // If the response is lost (aborted, network drop) the saver may still have
+    // committed the event, leaving kata.index stale. That is harmless: the saver
+    // places each write at head + 1 and treats this browser's own not-yet-seen
+    // writes as self-lag, so the next [test] still saves. kata.index resyncs on
+    // the next successful write, or on a browser refresh (edit.erb's setIndex).
+    .catch(() => {})
     .finally(() => { clearTimeout(timer); _interTestEventInProgress = false; callback(); });
   };
-
-  const resyncIndex = () =>
-    fetch(`/kata/next_index/${kata.id}`, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
-    // r.ok guards a web instance without this route (eg an older instance
-    // still up mid-deploy), which 404s: reject rather than parse its HTML.
-    .then(r => r.ok ? r.json() : Promise.reject())
-    .then(data => kata.setIndex(data.next_index))
-    .catch(() => {}); // leave kata.index as-is; a browser refresh also resyncs
 
 });
 </script>

--- a/source/app/views/kata/_index.erb
+++ b/source/app/views/kata/_index.erb
@@ -1,5 +1,6 @@
-<%# An incrementing index is held in the browser. %>
-<%# This allows out-of-sync mobbing detection.     %>
+<%# The browser holds the committed head-index it has observed, adopted from   %>
+<%# each saver write response (setIndex). It is sent on every write as the     %>
+<%# out-of-sync (mobbing) detection signal; the saver decides placement.       %>
 <input name="index" type="hidden" value="0">
 
 <script>
@@ -9,11 +10,6 @@ $(() => {
   const $index = $("input[name='index']");
 
   cd.kata.index = 0;
-
-  cd.kata.incrementIndex = () => {
-    cd.kata.index += 1;
-    $index.val(cd.kata.index);
-  };
 
   cd.kata.setIndex = (index) => {
     cd.kata.index = index;

--- a/source/app/views/kata/_run_tests.erb
+++ b/source/app/views/kata/_run_tests.erb
@@ -10,12 +10,27 @@
 'use strict';
 $(() => {
 
+  // True while a test run is in flight (fetch sent, response not yet handled).
+  // Guards against a second concurrent run: the [test] button, the predict
+  // buttons, and the Alt-T/R/A/G keybindings all funnel through runTests, and a
+  // re-entrant run would race the saver's compare-and-swap and store two test
+  // events out of chronological order. See docs/mobbing-concurrent-write-fix.md.
+  let runTestsInProgress = false;
+
   cd.kata.runTests = (onComplete) => {
     // Called from 2 places
     // 1. when you click the [test] button.
     // 2. when you click a [predict] button.
     // [X] This 30s timeout is different to runners max_seconds
     // from the start-points manifest.json file.
+
+    if (runTestsInProgress) {
+      // A run is already in flight. Ignore this re-entrant trigger, but run the
+      // caller's onComplete so the button-disable it just applied is undone.
+      if (onComplete) { onComplete(); }
+      return;
+    }
+    runTestsInProgress = true;
 
     const form = $('form');
     cd.saveCodeFromSyntaxHighlightEditors();
@@ -44,18 +59,18 @@ $(() => {
       .then(r => r.json())
       .then(handleResponse)
       .catch(err => cd.dialogError(err.message))
-      .finally(() => { clearTimeout(timer); cd.waitSpinner.fadeOut('slow', onComplete); });
+      .finally(() => { clearTimeout(timer); runTestsInProgress = false; cd.waitSpinner.fadeOut('slow', onComplete); });
     });
   };
 
   const handleResponse = (data) => {
-    const { light, outcome, stdout, stderr, status, log, out_of_sync: outOfSync, created, changed } = data;
+    const { light, outcome, stdout, stderr, status, log, out_of_sync: outOfSync, saved, created, changed } = data;
 
     if (outOfSync) {
       showAvatarsOutOfSync(light);
     }
     else {
-      refreshFromTest(light, stdout, stderr, status, created, changed);
+      refreshFromTest(light, stdout, stderr, status, created, changed, saved);
       if (runNeedsReverting(outcome)) {
         revert();
       }
@@ -63,8 +78,14 @@ $(() => {
     showInfoDialogs(outcome, log);
   };
 
-  const refreshFromTest = (light, stdout, stderr, status, created, changed) => {
-    cd.kata.setIndex(light.index + 1);
+  const refreshFromTest = (light, stdout, stderr, status, created, changed, saved) => {
+    // Only adopt the saver's index when the write actually committed. A failed
+    // save (a transient saver error, not mobbing) still returns the runner's
+    // light but commits nothing, so advancing here would push the index ahead of
+    // the head and the next [test] would show a false mobbing dialog.
+    if (saved) {
+      cd.kata.setIndex(light.index + 1);
+    }
     insertCreatedFiles(created);
     updateChangedFiles(changed);
     cd.kata.filenames.refresh();
@@ -110,7 +131,7 @@ $(() => {
     })
     .then(r => r.json())
     .then(data => {
-      cd.kata.incrementIndex();
+      cd.kata.setIndex(data.light.index + 1);
       cd.kata.editor.deleteFiles();
       for (const filename in data.files) {
         cd.kata.editor.createFile(filename, { content: data.files[filename] });

--- a/source/app/views/review/_checkout_button.erb
+++ b/source/app/views/review/_checkout_button.erb
@@ -66,7 +66,7 @@ $(() => {
     })
     .then(r => r.json())
     .then(data => {
-      kata.incrementIndex();
+      kata.setIndex(data.light.index + 1);
       kata.editor.deleteFiles();
       for (const filename in data.files) {
         kata.editor.createFile(filename, { content: data.files[filename] });

--- a/source/test/app_browser/browser_test_base.rb
+++ b/source/test/app_browser/browser_test_base.rb
@@ -1,0 +1,51 @@
+require_relative '../all'
+require 'capybara/minitest'
+
+# Base for browser (Capybara + Selenium) tests. These run inside the web
+# container and drive Firefox in the selenium container, which loads the real
+# web app at http://web:3000 over the compose network - so they exercise the
+# rendered page and its JavaScript end to end, unlike the in-process Rack tests
+# in app_controllers which never run browser JS.
+class BrowserTestBase < TestBase
+
+  include Capybara::DSL
+  include Capybara::Minitest::Assertions
+
+  Capybara.register_driver :selenium do |app|
+    Capybara::Selenium::Driver.new(app,
+                                   browser: :remote,
+                                   url: 'http://selenium:4444/wd/hub',
+                                   capabilities: :firefox)
+  end
+
+  def setup
+    super
+    Capybara.app_host       = 'http://web:3000'
+    Capybara.current_driver = :selenium
+    Capybara.run_server     = false
+  end
+
+  def teardown
+    Capybara.reset_sessions!
+    Capybara.app_host = nil
+    super
+  end
+
+  # - - - - - - - - - - - - - - - - - - -
+
+  def index_field_value
+    evaluate_script(%q{document.querySelector("input[name='index']").value})
+  end
+
+  # The hidden index field is set by JavaScript (on load, and after each write),
+  # so a read taken immediately after visit()/an action can race the handler.
+  # Poll until it holds the expected value.
+  def wait_for_index_field(expected)
+    20.times do
+      return if index_field_value == expected
+      sleep 0.3
+    end
+    flunk "index field never became #{expected.inspect} (was #{index_field_value.inspect})"
+  end
+
+end

--- a/source/test/app_browser/inter_test_file_event_advances_index_test.rb
+++ b/source/test/app_browser/inter_test_file_event_advances_index_test.rb
@@ -1,0 +1,38 @@
+require_relative 'browser_test_base'
+
+class InterTestFileEventAdvancesIndexTest < BrowserTestBase
+
+  test 'fEv5A1', %w(
+  | an inter-test file event advances the browser index by ADOPTING the
+  | saver-returned next_index (setIndex(newIndex) in _file_inter_test_events.erb),
+  | never by a local increment: after creating a file, the hidden index field
+  | equals the saver's committed head + 1.
+  ) do
+    id = saver.kata_create(starter_manifest)
+    visit "/kata/edit/#{id}"
+    wait_for_index_field('1') # page load sets index to events.length
+
+    # Invoke the real production inter-test handler (the [+] file-create button
+    # calls exactly this), rather than driving the file-menu/prompt UI.
+    execute_script(%q{cd.fileCreateITE('scratch.txt', function(){});})
+
+    head_next = wait_until_index_field_matches_saver(id)
+    assert_operator head_next, :>, 1, 'the file event should have advanced the head'
+  end
+
+  private
+
+  # The file event is async: the saver commits, then the browser's .then runs
+  # setIndex(newIndex). Poll until the hidden index field has adopted the saver's
+  # committed head + 1. Returns that value so the caller can assert it advanced.
+  def wait_until_index_field_matches_saver(id)
+    head_next = nil
+    30.times do
+      head_next = saver.kata_events(id).last['index'] + 1
+      return head_next if head_next > 1 && index_field_value == head_next.to_s
+      sleep 0.5
+    end
+    flunk "index field #{index_field_value.inspect} never matched saver head+1 (#{head_next})"
+  end
+
+end

--- a/source/test/app_browser/kata_edit_page_renders_test.rb
+++ b/source/test/app_browser/kata_edit_page_renders_test.rb
@@ -1,0 +1,17 @@
+require_relative 'browser_test_base'
+
+class KataEditPageRendersTest < BrowserTestBase
+
+  test 'bR9pQ2', %w(
+  | the kata edit page loads in a real browser and its on-load JavaScript runs:
+  | a freshly created v2 kata has only the index-0 event, so edit.erb's
+  | setIndex(events.length) sets the hidden index field to 1.
+  ) do
+    id = saver.kata_create(starter_manifest)
+    visit "/kata/edit/#{id}"
+    # edit.erb's setIndex(events.length) runs in JS on load; a fresh kata has
+    # only the index-0 event, so the hidden index field becomes "1".
+    wait_for_index_field('1')
+  end
+
+end

--- a/source/test/app_controllers/laptop_id_cookie_test.rb
+++ b/source/test/app_controllers/laptop_id_cookie_test.rb
@@ -1,0 +1,24 @@
+require_relative 'app_controller_test_base'
+
+class LaptopIdCookieTest < AppControllerTestBase
+
+  test 'F2a9C1a',
+  'a request with no laptop_id cookie mints one (64-char hex), mirroring csrf_token' do
+    assert_nil rack_mock_session.cookie_jar['laptop_id']
+    get '/alive'
+    laptop_id = rack_mock_session.cookie_jar['laptop_id']
+    refute_nil laptop_id, 'laptop_id cookie was not set'
+    assert_match(/\A[0-9a-f]{64}\z/, laptop_id, laptop_id)
+  end
+
+  test 'F2a9C1b',
+  'the laptop_id cookie is stable across reloads (a refresh keeps the same id)' do
+    get '/alive'
+    first = rack_mock_session.cookie_jar['laptop_id']
+    refute_nil first
+    get '/alive'
+    second = rack_mock_session.cookie_jar['laptop_id']
+    assert_equal first, second, 'laptop_id changed across reloads'
+  end
+
+end

--- a/source/test/app_controllers/mobbing_out_of_sync_test.rb
+++ b/source/test/app_controllers/mobbing_out_of_sync_test.rb
@@ -6,24 +6,33 @@ class MobbingOutOfSyncTest  < AppControllerTestBase
   include CaptureStdoutStderr
 
   test 'zW7B30', %w(
-  | given two (or more) laptops as the same avatar
+  | given two laptops as the same avatar (two different laptop_ids)
   | and one has not synced (by hitting refresh in their browser)
-  | and so their current traffic-light-index lags behind
-  | when they run their tests
-  | then it is a 200 (and not a 500)
-  | but no extra saver event is created.
+  | and so its current traffic-light-index lags behind the committed head
+  | when it runs its tests
+  | then genuine mobbing is detected: it is a 200 (and not a 500)
+  | the response is flagged out-of-sync (the mobbing dialog)
+  | and no extra saver event is created (the interfering write is not saved).
   ) do
     in_kata do |kata|
-      post_run_tests
+      # Laptop A: synced at the fresh kata (holding index 1), runs its tests
+      # and commits the event at index 1.
+      post_run_tests(index: 1)
       assert_equal 2, @index
+      assert_equal 1, saver.kata_events(kata.id).last['index']
 
-      post_run_tests
-      assert_equal 3, @index
-
-      stdout,stderr = capture_stdout_stderr {
-        post_run_tests({index: 2})
+      # Laptop B: a different browser (fresh cookies, so a different laptop_id),
+      # same avatar, that loaded when the kata was fresh and has NOT synced since,
+      # so it still holds the stale index 1. Its [test] therefore lands behind the
+      # head, over an event written by ANOTHER laptop - genuine mobbing.
+      clear_cookies
+      stdout, stderr = capture_stdout_stderr {
+        post_run_tests(index: 1)
       }
-      assert_equal 3, @index
+      assert last_response.ok?, last_response.body   # 200, not 500
+      assert json['out_of_sync'], json               # the mobbing dialog
+      assert_equal 1, saver.kata_events(kata.id).last['index'],
+        'the interfering write must not be saved'
       assert_equal '', stderr
       assert stdout.include?("Out of order event for #{kata.id}"), stdout
     end

--- a/source/test/app_controllers/mobbing_self_lag_after_lost_event_test.rb
+++ b/source/test/app_controllers/mobbing_self_lag_after_lost_event_test.rb
@@ -1,13 +1,15 @@
 require_relative 'app_controller_test_base'
 
-class MobbingResyncAfterLostEventTest < AppControllerTestBase
+class MobbingSelfLagAfterLostEventTest < AppControllerTestBase
 
-  test 'kT9mB2', %w(
+  test 'sLg7A1', %w(
   | A solo user on an unshared kata can lose the response to an inter-test
   | file event: the saver commits it and advances the head, but the browser's
-  | 2s abort fires so it never applies the returned index. The browser must be
-  | able to resync its index from GET /kata/next_index/:id and then run its
-  | tests cleanly - it must NOT get a false out-of-sync (mobbing) dialog.
+  | fetch aborts so it never applies the returned index and its own index stays
+  | stale. The next [test] is sent at that stale index, with NO resync. Because
+  | every event the browser missed was written by this same laptop, the saver
+  | accepts the write as self-lag (placing it at head + 1) instead of rejecting
+  | it - so the solo user gets NO false out-of-sync (mobbing) dialog.
   ) do
     in_kata do |kata|
       # Browser is synced: the only event is the index-0 created event,
@@ -16,7 +18,7 @@ class MobbingResyncAfterLostEventTest < AppControllerTestBase
       assert_equal 1, stale_index
 
       # The browser fires an inter-test file_create. The saver commits it
-      # (advancing the head) but the browser loses the response (2s abort),
+      # (advancing the head) but the browser loses the response (fetch abort),
       # so its own index counter stays at stale_index.
       post_json '/kata/file_create', {
         id:       @id,
@@ -29,14 +31,10 @@ class MobbingResyncAfterLostEventTest < AppControllerTestBase
       assert_operator committed_next, :>, stale_index,
         'the lost inter-test event should have advanced the head'
 
-      # Option A resync: rather than staying stale, the browser re-reads its
-      # authoritative next index from the server.
-      get '/kata/next_index/' + @id
-      assert last_response.ok?, last_response.body
-      assert_equal committed_next, json['next_index']
-
-      # With the resynced index the next run-tests saves cleanly: no mobbing.
-      post_run_tests(index: json['next_index'])
+      # No resync. The next [test] is sent at the STALE index. The saver sees the
+      # events the browser missed are all this same laptop's own writes, so it
+      # accepts the write as self-lag - no different laptop got in, no mobbing.
+      post_run_tests(index: stale_index)
       refute json['out_of_sync'], json
     end
   end

--- a/source/test/app_controllers/run_tests_save_error_test.rb
+++ b/source/test/app_controllers/run_tests_save_error_test.rb
@@ -1,0 +1,32 @@
+require_relative 'app_controller_test_base'
+require_relative 'capture_stdout_stderr'
+require_relative 'saver_ran_tests_raises_stub'
+
+class RunTestsSaveErrorTest < AppControllerTestBase
+
+  include CaptureStdoutStderr
+
+  test 'c2vE41', %w(
+  | when [test] runs but the saver save fails with a NON-out-of-order error
+  | (a transient saver outage, not mobbing), the response returns the runner's
+  | traffic-light and is a 200, is NOT flagged out-of-sync, commits no event,
+  | and signals saved:false so the browser does NOT advance its index. Advancing
+  | on a non-committing save is what later sends an ahead index and shows a
+  | false mobbing dialog.
+  ) do
+    in_kata do |kata|
+      set_class('saver', 'SaverRanTestsRaisesStub')
+      stdout, stderr = capture_stdout_stderr {
+        post_run_tests(index: 1)
+      }
+      assert last_response.ok?, last_response.body
+      refute json['out_of_sync'], json
+      assert_equal 1, saver.kata_events(kata.id).size,
+        'a failed save must not commit an event'
+      assert_equal false, json['saved'], json
+      assert_equal '', stderr
+      assert stdout.include?('saver unavailable'), stdout
+    end
+  end
+
+end

--- a/source/test/app_controllers/saver_ran_tests_raises_stub.rb
+++ b/source/test/app_controllers/saver_ran_tests_raises_stub.rb
@@ -1,0 +1,24 @@
+require_relative '../../app/services/saver_service'
+
+# A SaverService that behaves normally for setup/reads via its inherited methods,
+# but raises a NON-"Out of order event" SaverService::Error on the run_tests
+# save. Drives the run_tests rescue path for a transient saver failure (saver
+# down/overloaded/500/reset), which is distinct from an out-of-order (mobbing)
+# rejection. Injected via CYBER_DOJO_SAVER_CLASS.
+class SaverRanTestsRaisesStub < SaverService
+
+  MESSAGE = 'saver unavailable'
+
+  def kata_ran_tests(*)
+    raise SaverService::Error, MESSAGE
+  end
+
+  def kata_predicted_right(*)
+    raise SaverService::Error, MESSAGE
+  end
+
+  def kata_predicted_wrong(*)
+    raise SaverService::Error, MESSAGE
+  end
+
+end

--- a/source/test/app_models/app_models_test_base.rb
+++ b/source/test/app_models/app_models_test_base.rb
@@ -2,12 +2,12 @@ require_relative '../all'
 
 class AppModelsTestBase < TestBase
 
-  def kata_ran_tests(id, index, files, stdout, stderr, status, summary)
-    saver.kata_ran_tests(id, index, files, stdout, stderr, status, summary)
+  def kata_ran_tests(id, index, files, stdout, stderr, status, summary, laptop_id)
+    saver.kata_ran_tests(id, index, files, stdout, stderr, status, summary, laptop_id)
   end
 
-  def kata_revert(id, index, files, stdout, stderr, status, summary)
-    saver.kata_ran_tests(id, index, files, stdout, stderr, status, summary)
+  def kata_revert(id, index, files, stdout, stderr, status, summary, laptop_id)
+    saver.kata_ran_tests(id, index, files, stdout, stderr, status, summary, laptop_id)
   end
 
 end

--- a/source/test/app_models/kata_test.rb
+++ b/source/test/app_models/kata_test.rb
@@ -26,7 +26,7 @@ class KataTest < AppModelsTestBase
       stdout = content('dfg')
       stderr = content('uystd')
       status = 3
-      kata_ran_tests(kata.id, 1, files, stdout, stderr, status, ran_summary('red'))
+      kata_ran_tests(kata.id, 1, files, stdout, stderr, status, ran_summary('red'), laptop_id)
 
       assert_equal 2, kata.events.size
       light = kata.event(-1)
@@ -49,7 +49,7 @@ class KataTest < AppModelsTestBase
       stdout_1 = content("Expected: 42\nActual: 54")
       stderr_1 = content('assert failed')
       status_1 = 4
-      result = kata_ran_tests(kata.id, 1, files, stdout_1, stderr_1, status_1, ran_summary('red'))
+      result = kata_ran_tests(kata.id, 1, files, stdout_1, stderr_1, status_1, ran_summary('red'), laptop_id)
 
       filename = 'hiker.sh'
       hiker_rb = files[filename]['content']
@@ -57,13 +57,13 @@ class KataTest < AppModelsTestBase
       stdout_2 = content('All tests passed')
       stderr_2 = content('')
       status_2 = 0
-      result = kata_ran_tests(kata.id, result['next_index'], files, stdout_2, stderr_2, status_2, ran_summary('green'))
+      result = kata_ran_tests(kata.id, result['next_index'], files, stdout_2, stderr_2, status_2, ran_summary('green'), laptop_id)
 
       kata_revert(kata.id, result['next_index'], kata.event(1)['files'], stdout_1, stderr_1, status_1, {
           'time' => time.now,
         'colour' => 'red',
         'revert' => [ kata.id, 1 ]
-      });
+      }, laptop_id);
 
       light = kata.event(-1)
       assert_equal [ kata.id, 1 ], light['revert']
@@ -88,14 +88,14 @@ class KataTest < AppModelsTestBase
       stdout = content('xxxx')
       stderr = content('')
       status = 0
-      kata_ran_tests(kata.id, 1, files, stdout, stderr, status, ran_summary('green'))
+      kata_ran_tests(kata.id, 1, files, stdout, stderr, status, ran_summary('green'), laptop_id)
 
       assert_equal 'xxxx', kata.event(-1)['stdout']['content']
       assert_equal kata.event(1), kata.event(-1)
       stdout = content('')
       stderr = content('syntax-error')
       status = 1
-      kata_ran_tests(kata.id, 2, files, stdout, stderr, status, ran_summary('green'))
+      kata_ran_tests(kata.id, 2, files, stdout, stderr, status, ran_summary('green'), laptop_id)
 
       assert_equal 'syntax-error', kata.event(-1)['stderr']['content']
       assert_equal kata.event(2), kata.event(-1)
@@ -105,21 +105,23 @@ class KataTest < AppModelsTestBase
   #- - - - - - - - - - - - - - - - - - - - - - - - -
 
   test 'Fb9825', %w(
-  | given two laptops as the same avatar
+  | given two laptops as the same avatar (two different laptop_ids)
   | when one is behind (has not synced by hitting refresh in their browser)
   | and they hit the [test] button
   | a SaverService::Error is raised
   | and a new event is not created in the saver
   ) do
+    laptop_a = 'a1' * 32
+    laptop_b = 'b2' * 32
     in_new_kata do |kata|
       files = kata.event(-1)['files']
       stdout = content('aaaa')
       stderr = content('bbbb')
       status = 1
-      # 1st avatar
-      kata_ran_tests(kata.id, 1, files, stdout, stderr, status, ran_summary('red'))
-      kata_ran_tests(kata.id, 2, files, stdout, stderr, status, ran_summary('amber'))
-      kata_ran_tests(kata.id, 3, files, stdout, stderr, status, ran_summary('green'))
+      # 1st laptop drives the kata to head 3
+      kata_ran_tests(kata.id, 1, files, stdout, stderr, status, ran_summary('red'),   laptop_a)
+      kata_ran_tests(kata.id, 2, files, stdout, stderr, status, ran_summary('amber'), laptop_a)
+      kata_ran_tests(kata.id, 3, files, stdout, stderr, status, ran_summary('green'), laptop_a)
 
       events = kata.events
       assert_equal 4, events.size, :event_not_appended_to_events_json
@@ -129,10 +131,12 @@ class KataTest < AppModelsTestBase
         }
       }
 
-      # 2nd avatar - no refresh, so index not advanced to 2
+      # 2nd laptop has NOT refreshed, so it still holds the stale index 1. Its
+      # missed events (1..3) were written by a DIFFERENT laptop, so the saver
+      # rejects the write as mobbing and appends nothing.
       captured_stdout {
         assert_raises(SaverService::Error) {
-          kata_ran_tests(kata.id, 1, files, stdout, stderr, status, ran_summary('green'))
+          kata_ran_tests(kata.id, 1, files, stdout, stderr, status, ran_summary('green'), laptop_b)
         }
       }
 

--- a/source/test/app_services/http_json_requester_capturing_stub.rb
+++ b/source/test/app_services/http_json_requester_capturing_stub.rb
@@ -1,0 +1,19 @@
+require 'json'
+require 'ostruct'
+
+# Test double for the HTTP class SaverService uses. Captures the body of the
+# last request so a test can assert what SaverService sent, and returns a
+# minimal valid JSON response (keyed by the request path) so the responder
+# does not raise.
+class HttpJsonRequesterCapturingStub
+  class << self
+    attr_accessor :last_request_body
+  end
+  def initialize(_hostname, _port)
+  end
+  def request(req)
+    self.class.last_request_body = req.body
+    path = req.path.sub(%r{\A/}, '')
+    OpenStruct.new(body: { path => {} }.to_json)
+  end
+end

--- a/source/test/app_services/saver_service_forwards_laptop_id_test.rb
+++ b/source/test/app_services/saver_service_forwards_laptop_id_test.rb
@@ -1,0 +1,43 @@
+require_relative 'app_services_test_base'
+require_relative 'http_json_requester_capturing_stub'
+require 'json'
+
+class SaverServiceForwardsLaptopIdTest < AppServicesTestBase
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'F4c1A0',
+  'every event-committing write forwards its laptop_id argument in the POST body' do
+    set_http(HttpJsonRequesterCapturingStub)
+    files     = { 'hiker.h' => { 'content' => '' } }
+    content   = { 'content' => '', 'truncated' => false }
+    summary   = { colour: 'red' }
+    laptop_id = 'laptop-abc-123'
+    [
+      -> { saver.kata_file_create('kata-id', 1, files, 'f.txt', laptop_id) },
+      -> { saver.kata_file_delete('kata-id', 1, files, 'f.txt', laptop_id) },
+      -> { saver.kata_file_rename('kata-id', 1, files, 'a.txt', 'b.txt', laptop_id) },
+      -> { saver.kata_file_edit('kata-id', 1, files, laptop_id) },
+      -> { saver.kata_ran_tests('kata-id', 1, files, content, content, 0, summary, laptop_id) },
+      -> { saver.kata_predicted_right('kata-id', 1, files, content, content, 0, summary, laptop_id) },
+      -> { saver.kata_predicted_wrong('kata-id', 1, files, content, content, 0, summary, laptop_id) },
+      -> { saver.kata_reverted('kata-id', 1, files, content, content, 0, summary, laptop_id) },
+      -> { saver.kata_checked_out('kata-id', 1, files, content, content, 0, summary, laptop_id) },
+    ].each do |write|
+      write.call
+      body = JSON.parse(HttpJsonRequesterCapturingStub.last_request_body)
+      assert_equal laptop_id, body['laptop_id'], body.to_json
+    end
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'F4c1A1',
+  'a non-event write (kata_create) does not forward laptop_id (narrow scope)' do
+    set_http(HttpJsonRequesterCapturingStub)
+    saver.kata_create({ 'version' => 2 })
+    body = JSON.parse(HttpJsonRequesterCapturingStub.last_request_body)
+    refute body.key?('laptop_id'), body.to_json
+  end
+
+end

--- a/source/test/app_services/saver_service_test.rb
+++ b/source/test/app_services/saver_service_test.rb
@@ -78,7 +78,7 @@ class SaverServiceTest < AppServicesTestBase
   'kata_ran_tests() smoke test' do
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
-    saver.kata_ran_tests(kid, 1, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('amber'))
+    saver.kata_ran_tests(kid, 1, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('amber'), laptop_id)
     assert_equal 2, saver.kata_events(kid).size
   end
 
@@ -90,7 +90,7 @@ class SaverServiceTest < AppServicesTestBase
       duration: duration,
       colour: 'red',
       predicted: 'red'
-    })
+    }, laptop_id)
     assert_equal 2, saver.kata_events(kid).size
   end
 
@@ -102,7 +102,7 @@ class SaverServiceTest < AppServicesTestBase
       duration: duration,
       colour: 'red',
       predicted: 'green'
-    })
+    }, laptop_id)
     assert_equal 2, saver.kata_events(kid).size
   end
 
@@ -112,16 +112,16 @@ class SaverServiceTest < AppServicesTestBase
   'kata_reverted() smoke test' do
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
-    saver.kata_ran_tests(kid, 1, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('green'))
+    saver.kata_ran_tests(kid, 1, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('green'), laptop_id)
     saver.kata_ran_tests(kid, 2, manifest['visible_files'], content('stdout'), content('stderr'), 0, {
       duration: duration,
       colour: 'amber',
       predicted: 'red'
-    })
+    }, laptop_id)
     saver.kata_reverted(kid, 3, manifest['visible_files'], content('stdout'), content('stderr'), 0, {
       colour: 'green',
       revert: [kid, 1]
-    })
+    }, laptop_id)
     assert_equal 4, saver.kata_events(kid).size
   end
 
@@ -132,8 +132,8 @@ class SaverServiceTest < AppServicesTestBase
     manifest = starter_manifest
     gid = saver.group_create(manifest)
     kid1 = saver.group_join(gid)
-    saver.kata_ran_tests(kid1, 1, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('red'))
-    saver.kata_ran_tests(kid1, 2, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('amber'))
+    saver.kata_ran_tests(kid1, 1, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('red'), laptop_id)
+    saver.kata_ran_tests(kid1, 2, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('amber'), laptop_id)
     kid2 = saver.group_join(gid)
     saver.kata_checked_out(kid2, 1, manifest['visible_files'], content('stdout'), content('stderr'), 0, {
       colour: 'red',
@@ -142,7 +142,7 @@ class SaverServiceTest < AppServicesTestBase
         index: 2,
         avatarIndex: 46
       }
-    })
+    }, laptop_id)
     assert_equal 2, saver.kata_events(kid2).size
   end
 
@@ -155,7 +155,7 @@ class SaverServiceTest < AppServicesTestBase
     kid = saver.kata_create(manifest)
     files = manifest['visible_files']
     files[files.keys.first]['content'] += "\n# comment"
-    next_index = saver.kata_file_edit(kid, 1, files)
+    next_index = saver.kata_file_edit(kid, 1, files, laptop_id)
     assert_equal 2, next_index
   end
 
@@ -164,7 +164,7 @@ class SaverServiceTest < AppServicesTestBase
     manifest = starter_manifest
     manifest['version'] = 2
     kid = saver.kata_create(manifest)
-    next_index = saver.kata_file_create(kid, 1, manifest['visible_files'], 'new_file.txt')
+    next_index = saver.kata_file_create(kid, 1, manifest['visible_files'], 'new_file.txt', laptop_id)
     assert_equal 2, next_index
   end
 
@@ -174,7 +174,7 @@ class SaverServiceTest < AppServicesTestBase
     manifest['version'] = 2
     kid = saver.kata_create(manifest)
     existing_filename = manifest['visible_files'].keys.first
-    next_index = saver.kata_file_delete(kid, 1, manifest['visible_files'], existing_filename)
+    next_index = saver.kata_file_delete(kid, 1, manifest['visible_files'], existing_filename, laptop_id)
     assert_equal 2, next_index
   end
 
@@ -184,7 +184,7 @@ class SaverServiceTest < AppServicesTestBase
     manifest['version'] = 2
     kid = saver.kata_create(manifest)
     old_name = manifest['visible_files'].keys.first
-    next_index = saver.kata_file_rename(kid, 1, manifest['visible_files'], old_name, 'renamed_file.txt')
+    next_index = saver.kata_file_rename(kid, 1, manifest['visible_files'], old_name, 'renamed_file.txt', laptop_id)
     assert_equal 2, next_index
   end
 
@@ -251,10 +251,10 @@ class SaverServiceTest < AppServicesTestBase
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
     files = manifest['visible_files']
-    result = saver.kata_ran_tests(kid, 1, files, content('stdout'), content('stderr'), 0, ran_summary('red'))
+    result = saver.kata_ran_tests(kid, 1, files, content('stdout'), content('stderr'), 0, ran_summary('red'), laptop_id)
 
     files['hiker.sh']['content'] = files['hiker.sh']['content'].sub('6 * 9', '6 * 7')
-    result = saver.kata_ran_tests(kid, result['next_index'], files, content('stdout'), content('stderr'), 0, ran_summary('green'))
+    result = saver.kata_ran_tests(kid, result['next_index'], files, content('stdout'), content('stderr'), 0, ran_summary('green'), laptop_id)
 
     diffs = saver.diff_lines(kid, 1, result['next_index'] - 1)
 
@@ -274,10 +274,10 @@ class SaverServiceTest < AppServicesTestBase
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
     files = manifest['visible_files']
-    result = saver.kata_ran_tests(kid, 1, files, content('stdout'), content('stderr'), 0, ran_summary('red'))
+    result = saver.kata_ran_tests(kid, 1, files, content('stdout'), content('stderr'), 0, ran_summary('red'), laptop_id)
 
     files['hiker.sh']['content'] = files['hiker.sh']['content'].sub('6 * 9', '6 * 7')
-    result = saver.kata_ran_tests(kid, result['next_index'], files, content('stdout'), content('stderr'), 0, ran_summary('green'))
+    result = saver.kata_ran_tests(kid, result['next_index'], files, content('stdout'), content('stderr'), 0, ran_summary('green'), laptop_id)
 
     diffs = saver.diff_summary(kid, 1, result['next_index'] - 1)
 

--- a/source/test/print_coverage_summary.rb
+++ b/source/test/print_coverage_summary.rb
@@ -175,18 +175,18 @@ def coverage(stats, name)
     min = 100
   end  
   percent = stats[name][:coverage]
-  [ "#{name} coverage >= #{min}", percent.to_f >= min ]
+  [ "#{name} coverage >= #{min}", percent.to_f >= min, percent ]
 end
 
 #- - - - - - - - - - - - - - - - - - - - -
 
 def gather_done(stats, totals)
   done = [
-     [ 'total failures == 0', totals[:failure_count] == 0 ],
-     [ 'total errors == 0',   totals[:error_count] == 0 ],
-     [ 'total skips == 0',    totals[:skip_count] == 0],
-     [ 'total secs < 50',    totals[:time].to_f < 50 ]
-     #[ 'total assertions per sec > 20',  totals[:assertions_per_sec] > 20 ]
+     [ 'total failures == 0', totals[:failure_count] == 0, totals[:failure_count] ],
+     [ 'total errors == 0',   totals[:error_count]   == 0, totals[:error_count]   ],
+     [ 'total skips == 0',    totals[:skip_count]    == 0, totals[:skip_count]    ],
+     [ 'total secs < 50',     totals[:time].to_f < 50,     totals[:time]          ]
+     #[ 'total assertions per sec > 20',  totals[:assertions_per_sec] > 20, totals[:assertions_per_sec] ]
   ]
   module_names = %w(
     app_models
@@ -210,7 +210,7 @@ def print_done(done)
     puts 'DONE'
   else
     puts '!DONE'
-    no.each { |criteria| puts criteria[0] }
+    no.each { |criteria| puts "FAILED: #{criteria[0]} (actual #{criteria[2]})" }
   end
 end
 

--- a/source/test/run_browser.sh
+++ b/source/test/run_browser.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+# Browser (Capybara + Selenium) tests, run as a SEPARATE script from run.sh.
+# They drive the app end-to-end in the serving puma process (via Firefox in the
+# selenium container), so the in-process SimpleCov line-coverage that run.sh
+# enforces per module is not meaningful for them - hence they are kept out of
+# run.sh's coverage loop and its coverage-summary gate.
+#
+# They still load through all.rb, which requires test_coverage.rb, so a
+# COVERAGE_DIR and a module name (ARGV[0]) are set to satisfy that bootstrap;
+# the resulting coverage report is simply not gated here. A test failure exits
+# non-zero (minitest autorun), which bin/run_tests_in_container.sh propagates.
+
+module=app_browser
+
+coverage_dir=/tmp/cyber-dojo/coverage/${module}
+mkdir -p "${coverage_dir}"
+export COVERAGE_DIR=${coverage_dir}
+
+# Same externals as run.sh: talk to the real saver container (so a kata created
+# here is visible to the served app the browser loads), stub the runner.
+export RACK_ENV=test
+export CYBER_DOJO_SAVER_CLASS=SaverService
+export CYBER_DOJO_RUNNER_CLASS=RunnerStub
+
+export RUBYOPT='-W2 --enable-frozen-string-literal'
+
+echo
+echo "======${module}======"
+cd "${module}"
+testFiles=(*_test.rb)
+
+ruby -e "(%w( ../test_coverage.rb ) + %w( ${testFiles[*]} ).shuffle).map{ |file| require './'+file }" \
+  "${module}" "$@"

--- a/source/test/test_domain_helpers.rb
+++ b/source/test/test_domain_helpers.rb
@@ -39,6 +39,10 @@ module TestDomainHelpers
     1.6543
   end
 
+  def laptop_id
+    'a1' * 32 # a well-formed (64-char lowercase hex) laptop_id for tests to pass
+  end
+
   def ran_summary(colour)
     {
       'duration' => duration,


### PR DESCRIPTION
  Instructors running group sessions saw a false "mobbing?" dialog during ordinary
  solo work. Root cause: the browser proposed the event index optimistically, so any
  benign self-concurrency (an inter-test save still in flight when [test] fired, a
  lost response, a non-committing save) left the browser's index out of step, and the
  saver rejected the next [test] as "out of order" - surfaced as mobbing.

  This is the web half of the fix (the saver half shipped in saver #425/#426, which
  this depends on):

  - Adopt the saver-owned index. revert, checkout, auto-revert and inter-test events now set the index from the value the saver returns (head + 1); incrementIndex is gone. The browser no longer decides placement.
  - Mint a per-browser laptop_id and forward it on every write, so the saver can tell this browser's own lagged/concurrent writes (benign) from a different person's (real mobbing). laptop_id is a required argument threaded through SaverService.
  - Stop advancing the index when a save did not commit: run_tests returns saved:, and the browser only advances on saved == true.
  - Guard re-entrant test runs (button, predict buttons, Alt-keys all funnel through cd.kata.runTests) so a second concurrent test can't start mid-run.

  Adds a Capybara + Selenium harness (source/test/app_browser, a selenium compose
  service, and a separate run_browser.sh wired into make test) to exercise the page's
  JavaScript end to end - the in-process Rack tests never ran browser JS, which is
  where these index bugs lived. Plus controller/service tests for laptop_id forwarding,
  self-lag, and the non-committing-save case, and design docs under docs/.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>