### PR TITLE
Stamp per-tab tab_seq on browser writes and pass it to saver

### DIFF
--- a/docs/mobbing-overlay-diff-summary.md
+++ b/docs/mobbing-overlay-diff-summary.md
@@ -70,9 +70,16 @@ committed head moving, not by the buffer diverging from it: any commit from anot
 laptop advances the head and locks a behind tab, even when that commit changed no
 files. For example the other user presses [test] with no new edits; the head
 advances but its files match this tab's buffer exactly. `diff_summary` then returns
-only `:unchanged` entries and the overlay has nothing to list. The rendering must
-handle this case, showing that a refresh will lose nothing (rather than an empty or
-broken file list).
+only `:unchanged` entries and the overlay has nothing to list.
+
+The rendering must handle this case without showing an empty or broken file list.
+It must not, however, promise that a refresh will lose nothing. Firing the lock
+stops the poll loop, so the summary is frozen at the instant it fired (see the next
+section) and the overlay learns nothing more about the head. By the time the user
+refreshes, other laptops may have committed further and moved the head on, so a
+refresh resyncs to whatever the head is then, which may no longer match this tab's
+buffer. The wording should state only what is known at that instant: there were no
+file differences to show.
 
 ## The summary is a snapshot, not live
 

--- a/source/app/app.rb
+++ b/source/app/app.rb
@@ -145,22 +145,22 @@ class App < Sinatra::Base
 
   post '/kata/file_create' do
     content_type :json
-    saver.kata_file_create(id, params_files, params[:filename], laptop_id).to_json
+    saver.kata_file_create(id, params_files, params[:filename], laptop_id, tab_seq).to_json
   end
 
   post '/kata/file_delete' do
     content_type :json
-    saver.kata_file_delete(id, params_files, params[:filename], laptop_id).to_json
+    saver.kata_file_delete(id, params_files, params[:filename], laptop_id, tab_seq).to_json
   end
 
   post '/kata/file_rename' do
     content_type :json
-    saver.kata_file_rename(id, params_files, params[:old_filename], params[:new_filename], laptop_id).to_json
+    saver.kata_file_rename(id, params_files, params[:old_filename], params[:new_filename], laptop_id, tab_seq).to_json
   end
 
   post '/kata/file_edit' do
     content_type :json
-    saver.kata_file_edit(id, params_files, laptop_id).to_json
+    saver.kata_file_edit(id, params_files, laptop_id, tab_seq).to_json
   end
 
   # - - - - - - - - - - - - - - - -
@@ -248,7 +248,7 @@ class App < Sinatra::Base
     saver.kata_reverted(id, @files, @stdout, @stderr, @status, {
       colour: @colour,
       revert: args
-    }, laptop_id)
+    }, laptop_id, tab_seq)
     json.to_json
   end
 
@@ -269,7 +269,7 @@ class App < Sinatra::Base
     # The browser owns the displayed number and resolves the checkout light's
     # committed index lazily from its major_index, so the response carries no
     # position - just the source_event's files/outcome and checkout metadata.
-    saver.kata_checked_out(id, @files, @stdout, @stderr, @status, summary, laptop_id)
+    saver.kata_checked_out(id, @files, @stdout, @stderr, @status, summary, laptop_id, tab_seq)
     json.to_json
   end
 
@@ -356,6 +356,14 @@ class App < Sinatra::Base
     tab_id ? @laptop_id[0, 32] + tab_id : @laptop_id
   end
 
+  # This tab's monotonic write counter, forwarded to saver as the tab_seq half of
+  # the spooler idempotency key (laptop_id, tab_id, tab_seq). The browser stamps it
+  # on each event-write POST; a write without one (an old or non-JS client) yields
+  # nil, which saver accepts.
+  def tab_seq
+    params['tab_seq']
+  end
+
   def params_files
     data = Rack::Utils.parse_nested_query(params[:data])
     files_from(data['file_content'])
@@ -363,11 +371,11 @@ class App < Sinatra::Base
 
   def ran_tests(id, files, stdout, stderr, status, summary)
     if summary[:predicted] === 'none'
-      saver.kata_ran_tests(id, files, stdout, stderr, status, summary, laptop_id)
+      saver.kata_ran_tests(id, files, stdout, stderr, status, summary, laptop_id, tab_seq)
     elsif summary[:predicted] === summary[:colour]
-      saver.kata_predicted_right(id, files, stdout, stderr, status, summary, laptop_id)
+      saver.kata_predicted_right(id, files, stdout, stderr, status, summary, laptop_id, tab_seq)
     else
-      saver.kata_predicted_wrong(id, files, stdout, stderr, status, summary, laptop_id)
+      saver.kata_predicted_wrong(id, files, stdout, stderr, status, summary, laptop_id, tab_seq)
     end
   end
 

--- a/source/app/services/saver_service.rb
+++ b/source/app/services/saver_service.rb
@@ -87,45 +87,49 @@ class SaverService
 
   # - - - - - - - - - - - - - - - - - -
 
-  def kata_file_create(id, files, filename, laptop_id)
+  def kata_file_create(id, files, filename, laptop_id, tab_seq)
     @http.post(__method__, {
       id:id,
       files:files,
       filename:filename,
-      laptop_id:laptop_id
+      laptop_id:laptop_id,
+      tab_seq:tab_seq
     })
   end
 
-  def kata_file_delete(id, files, filename, laptop_id)
+  def kata_file_delete(id, files, filename, laptop_id, tab_seq)
     @http.post(__method__, {
       id:id,
       files:files,
       filename:filename,
-      laptop_id:laptop_id
+      laptop_id:laptop_id,
+      tab_seq:tab_seq
     })
   end
 
-  def kata_file_rename(id, files, old_filename, new_filename, laptop_id)
+  def kata_file_rename(id, files, old_filename, new_filename, laptop_id, tab_seq)
     @http.post(__method__, {
       id:id, 
       files:files,
       old_filename:old_filename,
       new_filename:new_filename,
-      laptop_id:laptop_id
+      laptop_id:laptop_id,
+      tab_seq:tab_seq
     })
   end
 
-  def kata_file_edit(id, files, laptop_id)
+  def kata_file_edit(id, files, laptop_id, tab_seq)
     @http.post(__method__, {
       id:id,
       files:files,
-      laptop_id:laptop_id
+      laptop_id:laptop_id,
+      tab_seq:tab_seq
     })
   end
 
   # - - - - - - - - - - - - - - - - - -
 
-  def kata_ran_tests(id, files, stdout, stderr, status, summary, laptop_id)
+  def kata_ran_tests(id, files, stdout, stderr, status, summary, laptop_id, tab_seq)
     @http.post(__method__, {
       id:id,
       files:files,
@@ -133,11 +137,12 @@ class SaverService
       stderr:stderr,
       status:status,
       summary:summary,
-      laptop_id:laptop_id
+      laptop_id:laptop_id,
+      tab_seq:tab_seq
     })
   end
 
-  def kata_predicted_right(id, files, stdout, stderr, status, summary, laptop_id)
+  def kata_predicted_right(id, files, stdout, stderr, status, summary, laptop_id, tab_seq)
     @http.post(__method__, {
       id:id,
       files:files,
@@ -145,11 +150,12 @@ class SaverService
       stderr:stderr,
       status:status,
       summary:summary,
-      laptop_id:laptop_id
+      laptop_id:laptop_id,
+      tab_seq:tab_seq
     })
   end
 
-  def kata_predicted_wrong(id, files, stdout, stderr, status, summary, laptop_id)
+  def kata_predicted_wrong(id, files, stdout, stderr, status, summary, laptop_id, tab_seq)
     @http.post(__method__, {
       id:id,
       files:files,
@@ -157,11 +163,12 @@ class SaverService
       stderr:stderr,
       status:status,
       summary:summary,
-      laptop_id:laptop_id
+      laptop_id:laptop_id,
+      tab_seq:tab_seq
     })
   end
 
-  def kata_reverted(id, files, stdout, stderr, status, summary, laptop_id)
+  def kata_reverted(id, files, stdout, stderr, status, summary, laptop_id, tab_seq)
     @http.post(__method__, {
       id:id,
       files:files,
@@ -169,11 +176,12 @@ class SaverService
       stderr:stderr,
       status:status,
       summary:summary,
-      laptop_id:laptop_id
+      laptop_id:laptop_id,
+      tab_seq:tab_seq
     })
   end
 
-  def kata_checked_out(id, files, stdout, stderr, status, summary, laptop_id)
+  def kata_checked_out(id, files, stdout, stderr, status, summary, laptop_id, tab_seq)
     @http.post(__method__, {
       id:id,
       files:files,
@@ -181,7 +189,8 @@ class SaverService
       stderr:stderr,
       status:status,
       summary:summary,
-      laptop_id:laptop_id
+      laptop_id:laptop_id,
+      tab_seq:tab_seq
     })
   end
 

--- a/source/app/views/kata/_file_inter_test_events.erb
+++ b/source/app/views/kata/_file_inter_test_events.erb
@@ -65,6 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const body = new URLSearchParams(args);
     body.set('data', new URLSearchParams(new FormData(document.querySelector('form'))).toString());
     body.set('tab_id', cd.mobbingPoll.tabId);
+    body.set('tab_seq', cd.kata.nextTabSeq());
     fetch(url, {
       method: 'POST',
       headers: {

--- a/source/app/views/kata/_run_tests.erb
+++ b/source/app/views/kata/_run_tests.erb
@@ -54,7 +54,7 @@ $(() => {
         'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
         'X-Requested-With': 'XMLHttpRequest'
       },
-      body: form.serialize() + '&tab_id=' + cd.mobbingPoll.tabId,
+      body: form.serialize() + '&tab_id=' + cd.mobbingPoll.tabId + '&tab_seq=' + cd.kata.nextTabSeq(),
       signal: controller.signal
     })
     .then(r => {
@@ -121,7 +121,7 @@ $(() => {
   };
 
   const revert = () => {
-    const args = { id: cd.kata.id, tab_id: cd.mobbingPoll.tabId };
+    const args = { id: cd.kata.id, tab_id: cd.mobbingPoll.tabId, tab_seq: cd.kata.nextTabSeq() };
     fetch('/kata/auto_revert', {
       method: 'POST',
       headers: {

--- a/source/app/views/kata/_tab_seq.erb
+++ b/source/app/views/kata/_tab_seq.erb
@@ -1,0 +1,22 @@
+<script>
+'use strict';
+$(() => {
+
+  // The browser owns this tab's monotonic write counter (tabSeq): incremented
+  // once per event-write POST (nextTabSeq) and sent as tab_seq. With laptop_id
+  // (cookie) and tab_id (per-tab), it forms the spooler's ordering and
+  // idempotency key (laptop_id, tab_id, tab_seq): the true production order for
+  // this tab, letting the spooler forward in order and dedup redelivery. It is
+  // not read by the stale-tab mobbing poll (that only needs tab_id).
+  cd.kata.tabSeq = 0;
+
+  // The next tab_seq to stamp on an event-write. A [test] that commits two saver
+  // events (a file_edit before the light) is one browser POST, so it carries one
+  // tab_seq; the counter advances per POST, not per committed event.
+  cd.kata.nextTabSeq = () => {
+    cd.kata.tabSeq += 1;
+    return cd.kata.tabSeq;
+  };
+
+});
+</script>

--- a/source/app/views/kata/_view_test.erb
+++ b/source/app/views/kata/_view_test.erb
@@ -8,6 +8,7 @@
   <%= partial('kata/image_name') %>
   <%= partial('kata/rag_lambda') %>
   <%= partial('kata/major_index') %>
+  <%= partial('kata/tab_seq') %>
   <%= partial('kata/max_seconds') %>
   <div class="left-column">
     <%= partial('kata/avatar_image') %>

--- a/source/app/views/review/_checkout_button.erb
+++ b/source/app/views/review/_checkout_button.erb
@@ -61,7 +61,8 @@ $(() => {
       src_major_index: event.major_index,
       src_minor_index: event.minor_index,
       src_avatar_index: review.avatarIndex,
-      tab_id: cd.mobbingPoll.tabId
+      tab_id: cd.mobbingPoll.tabId,
+      tab_seq: cd.kata.nextTabSeq()
     };
     cd.settings.showButton();
     fetch('/kata/checkout', {

--- a/source/test/app_browser/mobbing_test.rb
+++ b/source/test/app_browser/mobbing_test.rb
@@ -172,7 +172,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a tab_id this browser cannot have
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
 
@@ -190,7 +190,7 @@ class MobbingTest < BrowserTestBase
     my_tab = evaluate_script('cd.mobbingPoll.tabId')
     files = saver.kata_event(id, 0)['files']
     mine = stored_id('a1' * 16, my_tab)
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), mine)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), mine, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
 
@@ -210,7 +210,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a tab_id this browser cannot have
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
 
@@ -229,7 +229,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a tab_id this browser cannot have
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
 
@@ -250,7 +250,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a tab_id this browser cannot have
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
 
@@ -273,7 +273,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a tab_id this browser cannot have
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
 
@@ -294,7 +294,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a tab_id this browser cannot have
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
 
@@ -315,7 +315,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a tab_id this browser cannot have
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
 
@@ -337,7 +337,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a tab_id this browser cannot have
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
     assert_selector 'body.mobbing-stale', wait: 5
@@ -360,7 +360,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a tab_id this browser cannot have
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
     assert_selector 'body.mobbing-stale', wait: 5
@@ -383,7 +383,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a tab_id this browser cannot have
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
     assert_selector 'body.mobbing-stale', wait: 5
@@ -404,7 +404,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a tab_id this browser cannot have
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
 
@@ -427,7 +427,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a different laptop half
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
 
@@ -447,7 +447,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a different laptop half
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
     assert_selector '#mobbing-overlay', wait: 5
@@ -517,7 +517,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a different laptop half
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     refute_selector 'body.mobbing-stale'   # huge interval: not locked yet
     execute_script("document.dispatchEvent(new Event('visibilitychange'))")
@@ -537,7 +537,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a different laptop half
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     # Pretend the tab is hidden: a direct check must not lock.
     execute_script("Object.defineProperty(document, 'hidden', {configurable: true, get: () => true})")
@@ -574,7 +574,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a tab_id this browser cannot have
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
     assert_selector 'body.mobbing-stale', wait: 5
@@ -605,7 +605,7 @@ class MobbingTest < BrowserTestBase
 
     files = saver.kata_event(id, 0)['files']
     other = stored_id('a1' * 16, 'ff' * 16)   # a different laptop half
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
 
@@ -691,7 +691,7 @@ class MobbingTest < BrowserTestBase
     wait_for_edit_page_ready
 
     other = stored_id('c3' * 16, 'd4' * 16)   # a different laptop half
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
 
@@ -713,7 +713,7 @@ class MobbingTest < BrowserTestBase
       "document.querySelector('meta[name=laptop-id]').getAttribute('content')"
     )
     other = my_laptop + ('e5' * 16)   # my laptop half, a different tab half
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), other, next_tab_seq)
 
     execute_script("cd.mobbingPoll.intervalMs = 150; cd.mobbingPoll.enable()")
 

--- a/source/test/app_browser/traffic_light_lazy_index_resolution_test.rb
+++ b/source/test/app_browser/traffic_light_lazy_index_resolution_test.rb
@@ -17,9 +17,8 @@ class TrafficLightLazyIndexResolutionTest < BrowserTestBase
   ) do
     id = saver.kata_create(starter_manifest)
     files = saver.kata_event(id, 0)['files']
-    laptop = 'a1' * 32
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), laptop)
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('green'), laptop)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), laptop_id, next_tab_seq)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('green'), laptop_id, next_tab_seq)
 
     lights = saver.kata_events(id).reject { |e| FILE_EVENTS.include?(e['colour']) }
     expected_index = lights.last['index']
@@ -59,7 +58,7 @@ class TrafficLightLazyIndexResolutionTest < BrowserTestBase
   ) do
     id = saver.kata_create(starter_manifest)
     files = saver.kata_event(id, 0)['files']
-    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), 'a1' * 32)
+    saver.kata_ran_tests(id, files, content('out'), content('err'), 0, ran_summary('red'), laptop_id, next_tab_seq)
 
     visit "/kata/edit/#{id}"
     wait_for_edit_page_ready

--- a/source/test/app_models/app_models_test_base.rb
+++ b/source/test/app_models/app_models_test_base.rb
@@ -2,12 +2,12 @@ require_relative '../all'
 
 class AppModelsTestBase < TestBase
 
-  def kata_ran_tests(id, files, stdout, stderr, status, summary, laptop_id)
-    saver.kata_ran_tests(id, files, stdout, stderr, status, summary, laptop_id)
+  def kata_ran_tests(id, files, stdout, stderr, status, summary, laptop_id, tab_seq)
+    saver.kata_ran_tests(id, files, stdout, stderr, status, summary, laptop_id, tab_seq)
   end
 
-  def kata_revert(id, files, stdout, stderr, status, summary, laptop_id)
-    saver.kata_ran_tests(id, files, stdout, stderr, status, summary, laptop_id)
+  def kata_revert(id, files, stdout, stderr, status, summary, laptop_id, tab_seq)
+    saver.kata_ran_tests(id, files, stdout, stderr, status, summary, laptop_id, tab_seq)
   end
 
 end

--- a/source/test/app_models/kata_test.rb
+++ b/source/test/app_models/kata_test.rb
@@ -26,7 +26,7 @@ class KataTest < AppModelsTestBase
       stdout = content('dfg')
       stderr = content('uystd')
       status = 3
-      kata_ran_tests(kata.id, files, stdout, stderr, status, ran_summary('red'), laptop_id)
+      kata_ran_tests(kata.id, files, stdout, stderr, status, ran_summary('red'), laptop_id, next_tab_seq)
 
       assert_equal 2, kata.events.size
       light = kata.event(-1)
@@ -49,7 +49,7 @@ class KataTest < AppModelsTestBase
       stdout_1 = content("Expected: 42\nActual: 54")
       stderr_1 = content('assert failed')
       status_1 = 4
-      result = kata_ran_tests(kata.id, files, stdout_1, stderr_1, status_1, ran_summary('red'), laptop_id)
+      result = kata_ran_tests(kata.id, files, stdout_1, stderr_1, status_1, ran_summary('red'), laptop_id, next_tab_seq)
 
       filename = 'hiker.sh'
       hiker_rb = files[filename]['content']
@@ -57,13 +57,13 @@ class KataTest < AppModelsTestBase
       stdout_2 = content('All tests passed')
       stderr_2 = content('')
       status_2 = 0
-      result = kata_ran_tests(kata.id, files, stdout_2, stderr_2, status_2, ran_summary('green'), laptop_id)
+      result = kata_ran_tests(kata.id, files, stdout_2, stderr_2, status_2, ran_summary('green'), laptop_id, next_tab_seq)
 
       kata_revert(kata.id, kata.event(1)['files'], stdout_1, stderr_1, status_1, {
           'time' => time.now,
         'colour' => 'red',
         'revert' => [ kata.id, 1 ]
-      }, laptop_id);
+      }, laptop_id, next_tab_seq);
 
       light = kata.event(-1)
       assert_equal [ kata.id, 1 ], light['revert']
@@ -88,14 +88,14 @@ class KataTest < AppModelsTestBase
       stdout = content('xxxx')
       stderr = content('')
       status = 0
-      kata_ran_tests(kata.id, files, stdout, stderr, status, ran_summary('green'), laptop_id)
+      kata_ran_tests(kata.id, files, stdout, stderr, status, ran_summary('green'), laptop_id, next_tab_seq)
 
       assert_equal 'xxxx', kata.event(-1)['stdout']['content']
       assert_equal kata.event(1), kata.event(-1)
       stdout = content('')
       stderr = content('syntax-error')
       status = 1
-      kata_ran_tests(kata.id, files, stdout, stderr, status, ran_summary('green'), laptop_id)
+      kata_ran_tests(kata.id, files, stdout, stderr, status, ran_summary('green'), laptop_id, next_tab_seq)
 
       assert_equal 'syntax-error', kata.event(-1)['stderr']['content']
       assert_equal kata.event(2), kata.event(-1)
@@ -111,26 +111,26 @@ class KataTest < AppModelsTestBase
   | the saver accepts the write, placing it at head+1 (a behind write is no longer
   | rejected - detection is read-side now), so a new event IS created.
   ) do
-    laptop_a = 'a1' * 32
-    laptop_b = 'b2' * 32
+    laptop_ahead  = 'a1' * 32   # drives the kata to head
+    laptop_behind = 'b2' * 32   # has not refreshed, writes from a stale view
     in_new_kata do |kata|
       files = kata.event(-1)['files']
       stdout = content('aaaa')
       stderr = content('bbbb')
       status = 1
-      # 1st laptop drives the kata to head 3
-      kata_ran_tests(kata.id, files, stdout, stderr, status, ran_summary('red'),   laptop_a)
-      kata_ran_tests(kata.id, files, stdout, stderr, status, ran_summary('amber'), laptop_a)
-      kata_ran_tests(kata.id, files, stdout, stderr, status, ran_summary('green'), laptop_a)
+      # The ahead laptop drives the kata to head 3
+      kata_ran_tests(kata.id, files, stdout, stderr, status, ran_summary('red'),   laptop_ahead, next_tab_seq)
+      kata_ran_tests(kata.id, files, stdout, stderr, status, ran_summary('amber'), laptop_ahead, next_tab_seq)
+      kata_ran_tests(kata.id, files, stdout, stderr, status, ran_summary('green'), laptop_ahead, next_tab_seq)
 
       events = kata.events
       assert_equal 4, events.size, :event_not_appended_to_events_json
 
-      # 2nd laptop has NOT refreshed, so its write lands behind the head over events
-      # a DIFFERENT laptop wrote. The saver no longer rejects that: it places the
-      # write at head+1 and appends it. The stale tab is caught read-side (the
+      # The behind laptop has NOT refreshed, so its write lands behind the head over
+      # events a DIFFERENT laptop wrote. The saver no longer rejects that: it places
+      # the write at head+1 and appends it. The stale tab is caught read-side (the
       # browser poll), not here.
-      kata_ran_tests(kata.id, files, stdout, stderr, status, ran_summary('green'), laptop_b)
+      kata_ran_tests(kata.id, files, stdout, stderr, status, ran_summary('green'), laptop_behind, next_tab_seq)
 
       events = kata.events
       assert_equal 5, events.size, :event_appended_at_head_plus_1

--- a/source/test/app_services/saver_service_forwards_laptop_id_test.rb
+++ b/source/test/app_services/saver_service_forwards_laptop_id_test.rb
@@ -14,15 +14,15 @@ class SaverServiceForwardsLaptopIdTest < AppServicesTestBase
     summary   = { colour: 'red' }
     laptop_id = 'laptop-abc-123'
     [
-      -> { saver.kata_file_create('kata-id', files, 'f.txt', laptop_id) },
-      -> { saver.kata_file_delete('kata-id', files, 'f.txt', laptop_id) },
-      -> { saver.kata_file_rename('kata-id', files, 'a.txt', 'b.txt', laptop_id) },
-      -> { saver.kata_file_edit('kata-id', files, laptop_id) },
-      -> { saver.kata_ran_tests('kata-id', files, content, content, 0, summary, laptop_id) },
-      -> { saver.kata_predicted_right('kata-id', files, content, content, 0, summary, laptop_id) },
-      -> { saver.kata_predicted_wrong('kata-id', files, content, content, 0, summary, laptop_id) },
-      -> { saver.kata_reverted('kata-id', files, content, content, 0, summary, laptop_id) },
-      -> { saver.kata_checked_out('kata-id', files, content, content, 0, summary, laptop_id) },
+      -> { saver.kata_file_create('kata-id', files, 'f.txt', laptop_id, next_tab_seq) },
+      -> { saver.kata_file_delete('kata-id', files, 'f.txt', laptop_id, next_tab_seq) },
+      -> { saver.kata_file_rename('kata-id', files, 'a.txt', 'b.txt', laptop_id, next_tab_seq) },
+      -> { saver.kata_file_edit('kata-id', files, laptop_id, next_tab_seq) },
+      -> { saver.kata_ran_tests('kata-id', files, content, content, 0, summary, laptop_id, next_tab_seq) },
+      -> { saver.kata_predicted_right('kata-id', files, content, content, 0, summary, laptop_id, next_tab_seq) },
+      -> { saver.kata_predicted_wrong('kata-id', files, content, content, 0, summary, laptop_id, next_tab_seq) },
+      -> { saver.kata_reverted('kata-id', files, content, content, 0, summary, laptop_id, next_tab_seq) },
+      -> { saver.kata_checked_out('kata-id', files, content, content, 0, summary, laptop_id, next_tab_seq) },
     ].each do |write|
       write.call
       body = JSON.parse(HttpJsonRequesterCapturingStub.last_request_body)

--- a/source/test/app_services/saver_service_forwards_tab_seq_test.rb
+++ b/source/test/app_services/saver_service_forwards_tab_seq_test.rb
@@ -1,0 +1,47 @@
+require_relative 'app_services_test_base'
+require_relative 'http_json_requester_capturing_stub'
+require 'json'
+
+class SaverServiceForwardsTabSeqTest < AppServicesTestBase
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'Ta9f70',
+  'every event-committing write forwards its own (incrementing) tab_seq in the POST body' do
+    set_http(HttpJsonRequesterCapturingStub)
+    files     = { 'hiker.h' => { 'content' => '' } }
+    content   = { 'content' => '', 'truncated' => false }
+    summary   = { colour: 'red' }
+    laptop_id = 'laptop-abc-123'
+    [
+      ->(tab_seq) { saver.kata_file_create('kata-id', files, 'f.txt', laptop_id, tab_seq) },
+      ->(tab_seq) { saver.kata_file_delete('kata-id', files, 'f.txt', laptop_id, tab_seq) },
+      ->(tab_seq) { saver.kata_file_rename('kata-id', files, 'a.txt', 'b.txt', laptop_id, tab_seq) },
+      ->(tab_seq) { saver.kata_file_edit('kata-id', files, laptop_id, tab_seq) },
+      ->(tab_seq) { saver.kata_ran_tests('kata-id', files, content, content, 0, summary, laptop_id, tab_seq) },
+      ->(tab_seq) { saver.kata_predicted_right('kata-id', files, content, content, 0, summary, laptop_id, tab_seq) },
+      ->(tab_seq) { saver.kata_predicted_wrong('kata-id', files, content, content, 0, summary, laptop_id, tab_seq) },
+      ->(tab_seq) { saver.kata_reverted('kata-id', files, content, content, 0, summary, laptop_id, tab_seq) },
+      ->(tab_seq) { saver.kata_checked_out('kata-id', files, content, content, 0, summary, laptop_id, tab_seq) },
+    ].each do |write|
+      # A fresh, distinct tab_seq per write (1, 2, 3, ...): asserting each is
+      # forwarded verbatim proves the write sends the tab_seq it was given, not a
+      # constant, and that a changing value flows through faithfully.
+      tab_seq = next_tab_seq
+      write.call(tab_seq)
+      body = JSON.parse(HttpJsonRequesterCapturingStub.last_request_body)
+      assert_equal tab_seq, body['tab_seq'], body.to_json
+    end
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'Ta9f71',
+  'a non-event write (kata_create) does not forward tab_seq (narrow scope)' do
+    set_http(HttpJsonRequesterCapturingStub)
+    saver.kata_create({ 'version' => 2 })
+    body = JSON.parse(HttpJsonRequesterCapturingStub.last_request_body)
+    refute body.key?('tab_seq'), body.to_json
+  end
+
+end

--- a/source/test/app_services/saver_service_test.rb
+++ b/source/test/app_services/saver_service_test.rb
@@ -78,7 +78,7 @@ class SaverServiceTest < AppServicesTestBase
   'kata_ran_tests() smoke test' do
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
-    saver.kata_ran_tests(kid, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('amber'), laptop_id)
+    saver.kata_ran_tests(kid, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('amber'), laptop_id, next_tab_seq)
     assert_equal 2, saver.kata_events(kid).size
   end
 
@@ -90,7 +90,7 @@ class SaverServiceTest < AppServicesTestBase
       duration: duration,
       colour: 'red',
       predicted: 'red'
-    }, laptop_id)
+    }, laptop_id, next_tab_seq)
     assert_equal 2, saver.kata_events(kid).size
   end
 
@@ -102,7 +102,7 @@ class SaverServiceTest < AppServicesTestBase
       duration: duration,
       colour: 'red',
       predicted: 'green'
-    }, laptop_id)
+    }, laptop_id, next_tab_seq)
     assert_equal 2, saver.kata_events(kid).size
   end
 
@@ -112,16 +112,16 @@ class SaverServiceTest < AppServicesTestBase
   'kata_reverted() smoke test' do
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
-    saver.kata_ran_tests(kid, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('green'), laptop_id)
+    saver.kata_ran_tests(kid, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('green'), laptop_id, next_tab_seq)
     saver.kata_ran_tests(kid, manifest['visible_files'], content('stdout'), content('stderr'), 0, {
       duration: duration,
       colour: 'amber',
       predicted: 'red'
-    }, laptop_id)
+    }, laptop_id, next_tab_seq)
     saver.kata_reverted(kid, manifest['visible_files'], content('stdout'), content('stderr'), 0, {
       colour: 'green',
       revert: [kid, 1]
-    }, laptop_id)
+    }, laptop_id, next_tab_seq)
     assert_equal 4, saver.kata_events(kid).size
   end
 
@@ -132,8 +132,8 @@ class SaverServiceTest < AppServicesTestBase
     manifest = starter_manifest
     gid = saver.group_create(manifest)
     kid1 = saver.group_join(gid)
-    saver.kata_ran_tests(kid1, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('red'), laptop_id)
-    saver.kata_ran_tests(kid1, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('amber'), laptop_id)
+    saver.kata_ran_tests(kid1, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('red'), laptop_id, next_tab_seq)
+    saver.kata_ran_tests(kid1, manifest['visible_files'], content('stdout'), content('stderr'), 0, ran_summary('amber'), laptop_id, next_tab_seq)
     kid2 = saver.group_join(gid)
     saver.kata_checked_out(kid2, manifest['visible_files'], content('stdout'), content('stderr'), 0, {
       colour: 'red',
@@ -142,7 +142,7 @@ class SaverServiceTest < AppServicesTestBase
         index: 2,
         avatarIndex: 46
       }
-    }, laptop_id)
+    }, laptop_id, next_tab_seq)
     assert_equal 2, saver.kata_events(kid2).size
   end
 
@@ -155,7 +155,7 @@ class SaverServiceTest < AppServicesTestBase
     kid = saver.kata_create(manifest)
     files = manifest['visible_files']
     files[files.keys.first]['content'] += "\n# comment"
-    next_index = saver.kata_file_edit(kid, files, laptop_id)
+    next_index = saver.kata_file_edit(kid, files, laptop_id, next_tab_seq)
     assert_equal 2, next_index
   end
 
@@ -164,7 +164,7 @@ class SaverServiceTest < AppServicesTestBase
     manifest = starter_manifest
     manifest['version'] = 2
     kid = saver.kata_create(manifest)
-    next_index = saver.kata_file_create(kid, manifest['visible_files'], 'new_file.txt', laptop_id)
+    next_index = saver.kata_file_create(kid, manifest['visible_files'], 'new_file.txt', laptop_id, next_tab_seq)
     assert_equal 2, next_index
   end
 
@@ -174,7 +174,7 @@ class SaverServiceTest < AppServicesTestBase
     manifest['version'] = 2
     kid = saver.kata_create(manifest)
     existing_filename = manifest['visible_files'].keys.first
-    next_index = saver.kata_file_delete(kid, manifest['visible_files'], existing_filename, laptop_id)
+    next_index = saver.kata_file_delete(kid, manifest['visible_files'], existing_filename, laptop_id, next_tab_seq)
     assert_equal 2, next_index
   end
 
@@ -184,7 +184,7 @@ class SaverServiceTest < AppServicesTestBase
     manifest['version'] = 2
     kid = saver.kata_create(manifest)
     old_name = manifest['visible_files'].keys.first
-    next_index = saver.kata_file_rename(kid, manifest['visible_files'], old_name, 'renamed_file.txt', laptop_id)
+    next_index = saver.kata_file_rename(kid, manifest['visible_files'], old_name, 'renamed_file.txt', laptop_id, next_tab_seq)
     assert_equal 2, next_index
   end
 
@@ -251,10 +251,10 @@ class SaverServiceTest < AppServicesTestBase
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
     files = manifest['visible_files']
-    result = saver.kata_ran_tests(kid, files, content('stdout'), content('stderr'), 0, ran_summary('red'), laptop_id)
+    result = saver.kata_ran_tests(kid, files, content('stdout'), content('stderr'), 0, ran_summary('red'), laptop_id, next_tab_seq)
 
     files['hiker.sh']['content'] = files['hiker.sh']['content'].sub('6 * 9', '6 * 7')
-    result = saver.kata_ran_tests(kid, files, content('stdout'), content('stderr'), 0, ran_summary('green'), laptop_id)
+    result = saver.kata_ran_tests(kid, files, content('stdout'), content('stderr'), 0, ran_summary('green'), laptop_id, next_tab_seq)
 
     diffs = saver.diff_lines(kid, 1, result['next_index'] - 1)
 
@@ -274,10 +274,10 @@ class SaverServiceTest < AppServicesTestBase
     manifest = starter_manifest
     kid = saver.kata_create(manifest)
     files = manifest['visible_files']
-    result = saver.kata_ran_tests(kid, files, content('stdout'), content('stderr'), 0, ran_summary('red'), laptop_id)
+    result = saver.kata_ran_tests(kid, files, content('stdout'), content('stderr'), 0, ran_summary('red'), laptop_id, next_tab_seq)
 
     files['hiker.sh']['content'] = files['hiker.sh']['content'].sub('6 * 9', '6 * 7')
-    result = saver.kata_ran_tests(kid, files, content('stdout'), content('stderr'), 0, ran_summary('green'), laptop_id)
+    result = saver.kata_ran_tests(kid, files, content('stdout'), content('stderr'), 0, ran_summary('green'), laptop_id, next_tab_seq)
 
     diffs = saver.diff_summary(kid, 1, result['next_index'] - 1)
 

--- a/source/test/test_domain_helpers.rb
+++ b/source/test/test_domain_helpers.rb
@@ -43,6 +43,14 @@ module TestDomainHelpers
     'a1' * 32 # a well-formed (64-char lowercase hex) laptop_id for tests to pass
   end
 
+  # A fresh monotonic tab_seq for each event-write, mirroring the browser's
+  # per-tab counter. Distinct per call so saver's (laptop_id, tab_seq, colour)
+  # dedup never collapses two deliberate writes a test makes on one laptop_id.
+  def next_tab_seq
+    @next_tab_seq ||= 0
+    @next_tab_seq += 1
+  end
+
   def ran_summary(colour)
     {
       'duration' => duration,


### PR DESCRIPTION
  Establish the (laptop_id, tab_id, tab_seq) idempotency key end-to-end so
  saver can recognise a redelivered or re-fired write and dedup it. This is
  the bridge step before the spooler: landing the key now soaks the browser
  stamping in production and de-risks saver's contract change ahead of the
  durable, ordered forwarding the spooler will add.

  The browser owns tab_seq: a monotonic per-tab counter (cd.kata.nextTabSeq)
  incremented once per event-write POST - one value per browser action, even
  when a [test] commits two saver events. All four write paths stamp it (the
  ITE helper, run_tests, auto_revert, checkout). web forwards it through
  app.rb into saver_service's nine write methods as a required argument.

  Tests pass a required tab_seq too: a monotonic next_tab_seq helper gives a
  distinct value per write, since saver only dedups on a truthy tab_seq and a
  constant would collapse two same-laptop/same-colour writes. Adds a
  forwarding test mirroring the laptop_id one.